### PR TITLE
[JENKINS-32396] Make triggering per-branch projects optional 

### DIFF
--- a/src/main/java/jenkins/branch/BranchProperty.java
+++ b/src/main/java/jenkins/branch/BranchProperty.java
@@ -29,6 +29,7 @@ import hudson.ExtensionPoint;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.AbstractProject;
+import jenkins.scm.api.SCMRevision;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,20 @@ public abstract class BranchProperty extends AbstractDescribableImpl<BranchPrope
     @SuppressWarnings("unchecked")
     public final <P extends AbstractProject<P,B>,B extends AbstractBuild<P,B>> ProjectDecorator<P,B> decorator(P project) {
         return (ProjectDecorator<P, B>) decorator(project.getClass());
+    }
+
+    /**
+     * Gives implementations of BranchProperty the change to veto scheduling a build, defaults to true.
+     * @param project the project instance.
+     * @param branch the branch to which this property is applied.
+     * @param revision the latest revision to the branch.
+     * @param <P> the type of project.
+     * @param <B> the type of build of the project.
+     * @return Whether the property should allow the build to be scheduled.
+     */
+    public <P extends AbstractProject<P,B>,B extends AbstractBuild<P,B>> boolean shouldSchedule(
+        P project, Branch branch, SCMRevision revision) {
+      return true;
     }
 
     /**

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -1870,8 +1870,11 @@ public abstract class MultiBranchProject<P extends AbstractProject<P, R> & TopLe
                 if (!scheduleBuilds.isEmpty()) {
                     listener.getLogger().println("Scheduling builds for branches:");
                     for (Map.Entry<P, SCMRevision> entry : scheduleBuilds.entrySet()) {
-                        listener.getLogger().println("    " + factory.getBranch(entry.getKey()).getName());
-                        if (entry.getKey().scheduleBuild(0, new SCMTrigger.SCMTriggerCause("Branch indexing"))) {
+                        Branch branch = factory.getBranch(entry.getKey());
+                        listener.getLogger().println("    " + branch.getName());
+                        if (branch.hasProperty(NoTriggerBranchProperty.class)) {
+                          listener.getLogger().println("This branch's project is not triggered by source changes");
+                        } else if (entry.getKey().scheduleBuild(0, new SCMTrigger.SCMTriggerCause("Branch indexing"))) {
                             try {
                                 factory.setRevisionHash(entry.getKey(), entry.getValue());
                             } catch (IOException e) {

--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -24,6 +24,9 @@
 package jenkins.branch;
 
 import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import jenkins.scm.api.SCMRevision;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -38,6 +41,13 @@ public class NoTriggerBranchProperty extends BranchProperty {
     @DataBoundConstructor
     @SuppressWarnings("unused") // instantiated by stapler
     public NoTriggerBranchProperty() {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <P extends AbstractProject<P,B>,B extends AbstractBuild<P,B>> boolean shouldSchedule(
+        P project, Branch branch, SCMRevision revision) {
+      return false;
     }
 
     /** Our descriptor */

--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch;
+
+import hudson.Extension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * A branch property that blocks scheduling of projects on this branch due
+ * to source changes.
+ *
+ * @author Matt Moore
+ */
+@SuppressWarnings("unused") // instantiated by stapler
+public class NoTriggerBranchProperty extends BranchProperty {
+    /** Constructor for stapler. */
+    @DataBoundConstructor
+    @SuppressWarnings("unused") // instantiated by stapler
+    public NoTriggerBranchProperty() {
+    }
+
+    /** Our descriptor */
+    @Extension
+    @SuppressWarnings("unused") // instantiated by jenkins
+    public static class DescriptorImpl extends BranchPropertyDescriptor {
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.NoTriggerBranchProperty_DisplayName();
+        }
+    }
+}

--- a/src/main/resources/jenkins/branch/Messages.properties
+++ b/src/main/resources/jenkins/branch/Messages.properties
@@ -41,3 +41,4 @@ RateLimitBranchProperty.duration.day=Day
 RateLimitBranchProperty.duration.week=Week
 RateLimitBranchProperty.duration.month=Month
 RateLimitBranchProperty.duration.year=Year
+NoTriggerBranchProperty.DisplayName=Do not trigger projects on source changes


### PR DESCRIPTION
Add an advanced option to allow users to keep branch indexing from triggering the projects it creates/updates.