### PR TITLE
Need to define getBuildStatusIconClassName for compatibility with 1.576+ t:buildCaption

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -1801,6 +1801,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
             return baseColor.anime();
         }
 
+        @SuppressWarnings("unused") // used from Jelly
+        public String getBuildStatusIconClassName() {
+            return getIconColor().getIconClassName();
+        }
+
         /**
          * {@inheritDoc}
          */


### PR DESCRIPTION
Without this, the branch indexing log shows a broken icon in newer Jenkins releases.

https://github.com/jenkinsci/jenkins/commit/42190ed (from @tfennelly) was incompatible since it assumed that Jelly views were rendering one of the classes to which a new method was actually added, but in fact they can be and are used to render other classes via duck typing. `it.buildStatusIconClassName` was thus a poor choice; should have used `it.iconColor.iconClassName`, which would work with anything that already defined `public BallColor getIconColor()` (a reasonably safe assumption since the view was already evaluating `it.iconColor.description`).

@reviewbybees