### PR TITLE
scheduleBuild() uses the deprecated LegacyCodeCause

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -373,7 +373,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
             }
         }
         if (indexing.getTimeInMillis() == 0 && isBuildable()) {
-            scheduleBuild();
+            scheduleBuild(null);
         }
     }
 
@@ -1065,7 +1065,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
             }
         }
         if (reindex) {
-            scheduleBuild();
+            scheduleBuild(null);
         }
     }
 
@@ -1964,6 +1964,8 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     /**
      * {@inheritDoc}
      */
+    @Deprecated
+    @Override
     public boolean scheduleBuild() {
         return scheduleBuild(new Cause.LegacyCodeCause());
     }
@@ -1971,6 +1973,8 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     /**
      * {@inheritDoc}
      */
+    @Deprecated
+    @Override
     public boolean scheduleBuild(int quietPeriod) {
         return scheduleBuild(quietPeriod, new Cause.LegacyCodeCause());
     }


### PR DESCRIPTION
Led to junk in `indexing.xml` like this:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<jenkins.branch.MultiBranchProject_-BranchIndexing plugin="branch-api@0.2-beta-4">
  <actions>
    <hudson.model.CauseAction>
      <causes>
        <hudson.model.Cause_-LegacyCodeCause>
          <stackTrace>
            <trace>hudson.model.Cause$LegacyCodeCause.&lt;init&gt;(Cause.java:130)</trace>
            <trace>jenkins.branch.MultiBranchProject.scheduleBuild(MultiBranchProject.java:2002)</trace>
            …
          </stackTrace>
        </hudson.model.Cause_-LegacyCodeCause>
      </causes>
    </hudson.model.CauseAction>
  </actions>
  …
</jenkins.branch.MultiBranchProject_-BranchIndexing>
```

@reviewbybees esp. @stephenc