### PR TITLE
Removing misleading annotation

### DIFF
--- a/src/main/java/jenkins/branch/BranchPropertyDescriptor.java
+++ b/src/main/java/jenkins/branch/BranchPropertyDescriptor.java
@@ -48,7 +48,6 @@ public abstract class BranchPropertyDescriptor extends Descriptor<BranchProperty
      * @param project the project.
      * @return {@code} true iff this property is relevant with this project instance.
      */
-    @SuppressWarnings("unused") // by stapler
     public boolean isApplicable(@NonNull MultiBranchProject project) {
         return isApplicable(project.getDescriptor());
     }


### PR DESCRIPTION
In fact this method _is_ used by Java code, in the same source file in fact.

@reviewbybees esp. @stephenc