### PR TITLE
Ensure that SCMSource.setOwner is called

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -89,7 +89,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     /**
      * The user supplied branch sources.
      */
-    private /*almost final*/ PersistedList<BranchSource> sources = new PersistedList<BranchSource>(this);
+    private /*almost final*/ PersistedList<BranchSource> sources = new BranchSourceList(this);
 
     /**
      * The source for dead branches.
@@ -673,6 +673,22 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("JLS specification mandates UTF-8 as a supported encoding", e);
         }
+    }
+
+    private static class BranchSourceList extends PersistedList<BranchSource> {
+
+        BranchSourceList(MultiBranchProject<?,?> owner) {
+            super(owner);
+        }
+
+        @Override
+        protected void onModified() throws IOException {
+            super.onModified();
+            for (BranchSource branchSource : this) {
+                branchSource.getSource().setOwner((MultiBranchProject) owner);
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION
@recena noticed that in some `workflow-multibranch` tests, `AbstractGitSCMSource.retrieve` was getting null from `getCriteria()`. The reason is that nothing was calling `SCMSource.setOwner`. Normally this is called from `MultiBranchProject.onLoad` or `.submit`, but in the case of test code using `getSourcesList().add(…)` it was not. This patch just ensures that however the sources list is modified, `setOwner` will be called.

@reviewbybees