### PR TITLE
[JENKINS-30252] Defining environment variable BRANCH_NAME

### DIFF
--- a/src/main/java/jenkins/branch/BranchNameContributor.java
+++ b/src/main/java/jenkins/branch/BranchNameContributor.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.TaskListener;
+import java.io.IOException;
+
+/**
+ * Defines the environment variable {@code BRANCH_NAME} for multibranch builds.
+ */
+@Extension
+public class BranchNameContributor extends EnvironmentContributor {
+
+    /** {@inheritDoc} */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public void buildEnvironmentFor(Job j, EnvVars envs, TaskListener listener) throws IOException, InterruptedException {
+        ItemGroup parent = j.getParent();
+        if (parent instanceof MultiBranchProject) {
+            BranchProjectFactory projectFactory = ((MultiBranchProject) parent).getProjectFactory();
+            if (projectFactory.isProject(j)) {
+                // Note: not using Branch.name, since in the future that could be something different
+                // than SCMHead.name, which is what we really want here.
+                envs.put("BRANCH_NAME", projectFactory.getBranch(j).getHead().getName());
+            }
+        }
+    }
+
+}

--- a/src/main/resources/jenkins/branch/BranchNameContributor/buildEnv.jelly
+++ b/src/main/resources/jenkins/branch/BranchNameContributor/buildEnv.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2015 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
+    <t:buildEnvVar name="BRANCH_NAME">
+        <j:out value="${%blurb}"/>
+    </t:buildEnvVar>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/BranchNameContributor/buildEnv.properties
+++ b/src/main/resources/jenkins/branch/BranchNameContributor/buildEnv.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright 2015 CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+blurb=For a multibranch project, this will be set to the name of the branch being built, for example in case you wish to deploy to production from <code>master</code> but not from feature branches.


### PR DESCRIPTION
[JENKINS-30252](https://issues.jenkins-ci.org/browse/JENKINS-30252)

Could have restricted this to Workflow multibranch, but seemed generally useful.

@reviewbybees esp. @stephenc