### PR TITLE
Add PeriodicFolderTrigger by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>4.11-beta-1</version>
+      <version>5.1-SNAPSHOT</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -24,9 +24,11 @@
 
 package jenkins.branch;
 
+import antlr.ANTLRException;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor;
 import com.cloudbees.hudson.plugins.folder.computed.ChildObserver;
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
+import com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
@@ -80,6 +82,11 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
             if (f != null) {
                 projectFactories.add(f);
             }
+        }
+        try {
+            addTrigger(new PeriodicFolderTrigger("1d"));
+        } catch (ANTLRException x) {
+            assert false : x;
         }
     }
 
@@ -173,6 +180,11 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                 }
                                 if (project != null) {
                                     project.getSourcesList().addAll(createBranchSources());
+                                    try {
+                                        project.addTrigger(new PeriodicFolderTrigger("1d"));
+                                    } catch (ANTLRException x) {
+                                        assert false : x;
+                                    }
                                     observer.created(project);
                                     project.scheduleBuild();
                                     break;

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -86,7 +86,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
         try {
             addTrigger(new PeriodicFolderTrigger("1d"));
         } catch (ANTLRException x) {
-            assert false : x;
+            throw new IllegalStateException(x);
         }
     }
 
@@ -183,7 +183,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                     try {
                                         project.addTrigger(new PeriodicFolderTrigger("1d"));
                                     } catch (ANTLRException x) {
-                                        assert false : x;
+                                        throw new IllegalStateException(x);
                                     }
                                     observer.created(project);
                                     project.scheduleBuild();


### PR DESCRIPTION
Adding a one-day fallback trigger to newly created organization folders, since you normally want some kind of fallback even if there are webhooks.

Also adding it to the child multibranch projects. Ideally this would be something you could configure, somehow, but there is no mechanism for making such configurations currently, so we should at least have a sensible setting.

Downstream of https://github.com/jenkinsci/cloudbees-folder-plugin/pull/22.

@reviewbybees esp. @stephenc