### PR TITLE
[JENKINS-32179] Branch indexing always attempts to create a new project for conflicting branch names from multiple sources

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -299,6 +299,19 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     String rawName = branch.getName();
                     String encodedName = branch.getEncodedName();
                     P project = observer.shouldUpdate(encodedName);
+
+                    /*
+                     * Check observer.mayCreate:
+                     * 1. after observer.shouldUpdate so removal from the orphaned items list will still occur
+                     * 2. to check if this branch has been observed, and mark it as observed if it was not
+                     * 3. before verifying observer.shouldUpdate's retval, because if this branch has already been
+                     *    observed then we should stop here instead of updating or creating the project
+                     */
+                    if (!observer.mayCreate(encodedName)) {
+                        listener.getLogger().println("Ignoring duplicate branch project " + rawName);
+                        return;
+                    }
+
                     if (project != null) {
                         if (!_factory.isProject(project)) {
                             listener.getLogger().println("Detected unsupported subitem " + project + ", skipping");
@@ -330,10 +343,6 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 e.printStackTrace(listener.error("Could not save changes to " + rawName));
                             }
                         }
-                        return;
-                    }
-                    if (!observer.mayCreate(encodedName)) {
-                        listener.getLogger().println("Ignoring duplicate branch project " + rawName);
                         return;
                     }
                     project = _factory.newInstance(branch);


### PR DESCRIPTION
[JENKINS-32179](https://issues.jenkins-ci.org/browse/JENKINS-32179)

observer.mayCreate is a slight misnomer, since it actually marks the
branch as observed and its return value is whether it has been observed.
Move this check to before updating/creating branches, since we don't
want to do either if the branch has been observed already.