### PR TITLE
Remove useless MultiBranchProjectDescriptor#getSCMDescriptors() API.

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProjectDescriptor.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectDescriptor.java
@@ -35,7 +35,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The {@link Descriptor} for {@link MultiBranchProject}s.
+ * <p>The {@link Descriptor} for {@link MultiBranchProject}s.</p>
+ *
+ * <p>Compatible {@link hudson.scm.SCM}s displayed by {@link jenkins.scm.impl.SingleSCMSource} (via their
+ * {@link hudson.scm.SCMDescriptor}) can be defined by overriding {@link #isApplicable(Descriptor)}:</p>
+ * <pre>
+ * &#64;Override
+ * public boolean isApplicable(Descriptor descriptor) {
+ *     if (descriptor instanceof SCMDescriptor) {
+ *         SCMDescriptor d = (SCMDescriptor) descriptor;
+ *         // Your logic
+ *     }
+ *     return super.isApplicable(descriptor);
+ * }
+ * </pre>
  *
  * @author Stephen Connolly
  */

--- a/src/main/java/jenkins/branch/MultiBranchProjectDescriptor.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectDescriptor.java
@@ -28,7 +28,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
 import hudson.model.TopLevelItemDescriptor;
-import hudson.scm.SCMDescriptor;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSourceDescriptor;
 
@@ -66,15 +65,6 @@ public abstract class MultiBranchProjectDescriptor extends AbstractFolderDescrip
     public List<SCMSourceDescriptor> getSCMSourceDescriptors(boolean onlyUserInstantiable) {
         return SCMSourceDescriptor.forOwner(getClazz(), onlyUserInstantiable);
     }
-
-    /**
-     * Gets the {@link SCMDescriptor}s, primarily used by {@link jenkins.scm.impl.SingleSCMSource}.
-     *
-     * @return the {@link SCMDescriptor}s.
-     */
-    @SuppressWarnings("unused") // used by stapler
-    @NonNull
-    public abstract List<SCMDescriptor<?>> getSCMDescriptors();
 
     /**
      * Returns the {@link BranchProjectFactoryDescriptor}s.

--- a/src/test/java/jenkins/branch/harness/MultiBranchImpl.java
+++ b/src/test/java/jenkins/branch/harness/MultiBranchImpl.java
@@ -24,11 +24,7 @@
 
 package jenkins.branch.harness;
 
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
-import java.util.List;
 import java.util.logging.Logger;
 
 import hudson.Extension;
@@ -37,8 +33,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
-import hudson.scm.SCM;
-import hudson.scm.SCMDescriptor;
 import jenkins.branch.Branch;
 import jenkins.branch.BranchProjectFactory;
 import jenkins.branch.MultiBranchProject;
@@ -105,11 +99,6 @@ public class MultiBranchImpl extends MultiBranchProject<FreeStyleProject, FreeSt
         @Override 
         public TopLevelItem newInstance(ItemGroup parent, String name) {
             return new MultiBranchImpl(parent, name);
-        }
-
-        @Override 
-        public List<SCMDescriptor<?>> getSCMDescriptors() {
-            return SCM.all();
         }
     }
 }


### PR DESCRIPTION
`SingleSCMSource`'s config-detail.jelly uses
[`SingleSCMSource.DescriptorImpl#getSCMDescriptors(SCMSourceOwner)`](https://github.com/jenkinsci/scm-api-plugin/blob/7c99d7f705408a457065fa2d9ef89be8b900b805/src/main/java/jenkins/scm/impl/SingleSCMSource.java#L183-L204),
contrary to the Javadoc on the method removed by this commit.


If you were to implement the method removed by this commit, you could make the method always throw an `IllegalStateException` and it would never occur.