### PR TITLE
[JENKINS-34259] Some links are broken in the Welcome page

### DIFF
--- a/src/main/java/jenkins/branch/BaseEmptyView.java
+++ b/src/main/java/jenkins/branch/BaseEmptyView.java
@@ -33,6 +33,14 @@ public class BaseEmptyView extends View {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEditable() {
+        return false;
+    }
+
+    /**
      * Equal to any view of the same class and owner.
      * {@inheritDoc}
      */

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -554,7 +554,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     @Override
     public View getPrimaryView() {
         if (getItems().isEmpty()) {
-            // when there's no branches to show, switch to the special welcome view
+            // when there are no branches nor pull requests to show, switch to the special welcome view
             return getWelcomeView();
         }
         return super.getPrimaryView();
@@ -565,6 +565,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
      */
     protected View getWelcomeView() {
         return new MultiBranchProjectEmptyView(this);
+    }
+
+    @Override
+    public View getView(String name) {
+        return getPrimaryView();
     }
 
     /**

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -252,7 +252,8 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
     }
 
     /**
-     * Will create an specialized view when there are no repositories found, which contain a Jenkinsfile
+     * Will create an specialized view when there are no repositories or branches found, which contain a Jenkinsfile
+     * or other MARKER file.
      */
     @Override
     public View getPrimaryView() {
@@ -260,6 +261,11 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
             return new OrganizationFolderEmptyView(this);
         }
         return super.getPrimaryView();
+    }
+
+    @Override
+    public View getView(String name) {
+        return getPrimaryView();
     }
 
     @Extension


### PR DESCRIPTION
[JENKINS-34259](https://issues.jenkins-ci.org/browse/JENKINS-34259)

- [x] **People** link
- [x] **Build History** link
- [x] **Welcome Page** `http://localhost:8080/jenkins/job/je2/view/Welcome`
- [x] Remove **Edit View** option

![jenkins-34259-1](https://cloud.githubusercontent.com/assets/1021745/14880180/c1990f00-0d2d-11e6-81d5-1eeddfe1b0e0.png)

@reviewbybees especially, @kzantow since he worked on `BaseEmptyView`.