### PR TITLE
Switched from SCMTrigger.SCMTriggerCause to BranchIndexingCause

### DIFF
--- a/src/main/java/jenkins/branch/BranchIndexingCause.java
+++ b/src/main/java/jenkins/branch/BranchIndexingCause.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.model.Cause;
+import hudson.model.ItemGroup;
+import hudson.model.Run;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+
+/**
+ * Declares that a build was due to branch indexing.
+ */
+public final class BranchIndexingCause extends Cause {
+
+    private transient MultiBranchProject<?,?> multiBranchProject;
+
+    BranchIndexingCause() {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void onAddedTo(Run build) {
+        ItemGroup<?> g = build.getParent().getParent();
+        if (g instanceof MultiBranchProject) {
+            multiBranchProject = (MultiBranchProject) g;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public void onLoad(Run<?,?> build) {
+        onAddedTo(build);
+    }
+
+    /**
+     * Gets the associated multibranch project.
+     * @return the multibranch project (nonnull unless deleted before restart)
+     */
+    @CheckForNull
+    public MultiBranchProject<?,?> getMultiBranchProject() {
+        return multiBranchProject;
+    }
+
+    @Restricted(DoNotUse.class) // Jelly
+    @CheckForNull
+    public String getIndexingUrl() {
+        return multiBranchProject != null ? multiBranchProject.getIndexing().getUrl() : null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    @Override
+    public String getShortDescription() {
+        return "Branch indexing";
+    }
+
+}

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -44,7 +44,6 @@ import hudson.model.View;
 import hudson.scm.PollingResult;
 import hudson.security.ACL;
 import hudson.security.Permission;
-import hudson.triggers.SCMTrigger;
 import hudson.util.PersistedList;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
@@ -282,8 +281,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
      * {@inheritDoc}
      */
     public void onSCMSourceUpdated(@NonNull SCMSource source) {
-        SCMTrigger.SCMTriggerCause cause = new SCMTrigger.SCMTriggerCause(source.getDescriptor().getDisplayName());
-        scheduleBuild(0, cause);
+        scheduleBuild(0, new BranchIndexingCause());
     }
 
     /**
@@ -363,7 +361,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     }
 
     private void scheduleBuild(BranchProjectFactory<P,R> factory, final P item, SCMRevision revision, TaskListener listener, String name) {
-        if (ParameterizedJobMixIn.scheduleBuild2(item, 0, new CauseAction(new SCMTrigger.SCMTriggerCause("Branch indexing"))) != null) {
+        if (ParameterizedJobMixIn.scheduleBuild2(item, 0, new CauseAction(new BranchIndexingCause())) != null) {
             listener.getLogger().println("Scheduled build for branch: " + name);
             try {
                 factory.setRevisionHash(item, revision);
@@ -371,7 +369,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 e.printStackTrace(listener.error("Could not update last revision hash"));
             }
         } else {
-            listener.getLogger().println("Failed to schedule build for branch: " + name);
+            listener.getLogger().println("Did not schedule build for branch: " + name);
         }
     }
 

--- a/src/main/resources/jenkins/branch/BranchIndexingCause/description.jelly
+++ b/src/main/resources/jenkins/branch/BranchIndexingCause/description.jelly
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <j:set var="url" value="${it.indexingUrl}"/>
+    <j:choose>
+        <j:when test="${url != null}">
+            <a href="${rootURL}/${url}console">Branch indexing</a>
+        </j:when>
+        <j:otherwise>
+            Branch indexing
+        </j:otherwise>
+    </j:choose>
+</j:jelly>


### PR DESCRIPTION
`SCMTriggerCause` is not really appropriate for multibranch projects. For example, it tries to save a polling log, which in fact has bogus text. And the hyperlink is not useful.

@reviewbybees