### PR TITLE
[JENKINS-32396] Option to suppress automatic SCM trigger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,29 @@
       <version>1.24</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>2.4.4</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency> <!-- TODO for GitSampleRepoRule; should this be pushed up into scm-api, or git, or jenkins-test-harness? -->
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+      <version>2.0</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/jenkins/branch/BranchIndexingCause.java
+++ b/src/main/java/jenkins/branch/BranchIndexingCause.java
@@ -42,7 +42,7 @@ public final class BranchIndexingCause extends Cause {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public void onAddedTo(Run build) {
@@ -53,7 +53,7 @@ public final class BranchIndexingCause extends Cause {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public void onLoad(Run<?,?> build) {
@@ -76,7 +76,7 @@ public final class BranchIndexingCause extends Cause {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     @Override
     public String getShortDescription() {

--- a/src/main/java/jenkins/branch/BranchProperty.java
+++ b/src/main/java/jenkins/branch/BranchProperty.java
@@ -82,7 +82,7 @@ public abstract class BranchProperty extends AbstractDescribableImpl<BranchPrope
         if (Util.isOverridden(BranchProperty.class, getClass(), "decorator", Class.class) && AbstractProject.class.isAssignableFrom(clazz)) {
             return decorator(clazz);
         } else {
-            throw new AbstractMethodError("you must implement jobDecorator");
+            throw new AbstractMethodError("you must implement jobDecorator in " + getClass());
         }
     }
 

--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Job;
+import hudson.model.Queue;
+import hudson.model.Run;
+import java.util.List;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Suppresses builds due to {@link BranchIndexingCause}.
+ */
+@Restricted(NoExternalUse.class)
+public class NoTriggerBranchProperty extends BranchProperty {
+
+    @DataBoundConstructor
+    public NoTriggerBranchProperty() {}
+
+    @Override
+    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
+        return null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BranchPropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.NoTriggerBranchProperty_suppress_automatic_scm_triggering();
+        }
+
+    }
+
+    @Extension
+    public static class Dispatcher extends Queue.QueueDecisionHandler {
+
+        @SuppressWarnings({"unchecked", "rawtypes"}) // untypable
+        @Override
+        public boolean shouldSchedule(Queue.Task p, List<Action> actions) {
+            for (Action action :  actions) {
+                if (action instanceof CauseAction) {
+                    for (Cause c : ((CauseAction) action).getCauses()) {
+                        if (c instanceof BranchIndexingCause) {
+                            if (p instanceof Job) {
+                                Job j = (Job) p;
+                                if (j.getParent() instanceof MultiBranchProject) {
+                                    for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
+                                        if (prop instanceof NoTriggerBranchProperty) {
+                                            return false;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+    }
+
+}

--- a/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
@@ -1,0 +1,116 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
+import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Job;
+import hudson.model.Queue;
+import hudson.util.FormValidation;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * Defines {@link NoTriggerBranchProperty} on selected branches.
+ */
+@Restricted(NoExternalUse.class)
+public class NoTriggerOrganizationFolderProperty extends AbstractFolderProperty<OrganizationFolder> {
+
+    /** Regexp of branch names to trigger. */
+    private final String branches;
+
+    @DataBoundConstructor
+    public NoTriggerOrganizationFolderProperty(String branches) {
+        this.branches = branches;
+    }
+    
+    public String getBranches() {
+        return branches;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractFolderPropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.NoTriggerBranchProperty_suppress_automatic_scm_triggering();
+        }
+
+        public FormValidation doCheckBranches(@QueryParameter String value) {
+            try {
+                Pattern.compile(value);
+                return FormValidation.ok();
+            } catch (PatternSyntaxException x) {
+                return FormValidation.error(x.getMessage());
+            }
+        }
+
+    }
+
+    @Extension
+    public static class Dispatcher extends Queue.QueueDecisionHandler {
+
+        @SuppressWarnings({"unchecked", "rawtypes"}) // untypable
+        @Override
+        public boolean shouldSchedule(Queue.Task p, List<Action> actions) {
+            for (Action action :  actions) {
+                if (action instanceof CauseAction) {
+                    for (Cause c : ((CauseAction) action).getCauses()) {
+                        if (c instanceof BranchIndexingCause) {
+                            if (p instanceof Job) {
+                                Job j = (Job) p;
+                                if (j.getParent() instanceof MultiBranchProject) {
+                                    MultiBranchProject mbp = (MultiBranchProject) j.getParent();
+                                    if (mbp.getParent() instanceof OrganizationFolder) {
+                                        NoTriggerOrganizationFolderProperty prop = ((OrganizationFolder) mbp.getParent()).getProperties().get(NoTriggerOrganizationFolderProperty.class);
+                                        if (prop != null) {
+                                            // Not necessarily the same as j.getName(), which may be encoded:
+                                            String name = mbp.getProjectFactory().getBranch(j).getName();
+                                            if (!name.matches(prop.getBranches())) {
+                                                return false;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+    }
+
+}

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -146,7 +146,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                             }
                             List<BranchSource> branchSources = new ArrayList<BranchSource>();
                             for (SCMSource source : sources) {
-                                // TODO we probably need to define a BranchPropertyStrategyFactory (cf. JENKINS-22242)
+                                // TODO do we want/need a more general BranchPropertyStrategyFactory?
                                 branchSources.add(new BranchSource(source));
                             }
                             sources = null; // make sure complete gets called just once

--- a/src/main/resources/jenkins/branch/Messages.properties
+++ b/src/main/resources/jenkins/branch/Messages.properties
@@ -23,6 +23,7 @@
 #
 DefaultBranchPropertyStrategy.DisplayName=All branches get the same properties
 NamedExceptionsBranchPropertyStrategy.DisplayName=Named branches get different properties
+NoTriggerBranchProperty.suppress_automatic_scm_triggering=Suppress automatic SCM triggering
 RateLimitBranchProperty.ApproxDaysBetweenBuilds=Approximately {0,choice,1\#a day|1<{0,number,integer} days} between builds
 RateLimitBranchProperty.ApproxHoursBetweenBuilds=Approximately {0,choice,1\#an hour|1<{0,number,integer} hours} between builds
 RateLimitBranchProperty.ApproxMinsBetweenBuilds=Approximately {0,choice,1\#a minute|1<{0,number,integer} minutes} between builds

--- a/src/main/resources/jenkins/branch/NoTriggerBranchProperty/config.jelly
+++ b/src/main/resources/jenkins/branch/NoTriggerBranchProperty/config.jelly
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"/>

--- a/src/main/resources/jenkins/branch/NoTriggerBranchProperty/help.html
+++ b/src/main/resources/jenkins/branch/NoTriggerBranchProperty/help.html
@@ -1,0 +1,3 @@
+<div>
+    Suppresses the normal SCM commit trigger coming from branch indexing.
+</div>

--- a/src/main/resources/jenkins/branch/NoTriggerOrganizationFolderProperty/config.jelly
+++ b/src/main/resources/jenkins/branch/NoTriggerOrganizationFolderProperty/config.jelly
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:section title="${%Automatic branch project triggering}">
+        <f:entry title="${%Branch names to build automatically}" field="branches">
+            <f:textbox default=".*"/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/NoTriggerOrganizationFolderProperty/help-branches.html
+++ b/src/main/resources/jenkins/branch/NoTriggerOrganizationFolderProperty/help-branches.html
@@ -1,0 +1,6 @@
+<div>
+    Allows you to control the SCM commit trigger coming from branch indexing.
+    Supply a regular expression of branch names, for example <code>(?!release.*).*</code> or <code>PR-\d+</code>.
+    Matching branches will be triggered automatically.
+    (You may still build other branches manually or via CLI/REST.)
+</div>

--- a/src/main/resources/jenkins/branch/harness/BranchProjectFactoryImpl/config.jelly
+++ b/src/main/resources/jenkins/branch/harness/BranchProjectFactoryImpl/config.jelly
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"/>

--- a/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
+import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.branch.harness.MultiBranchImpl;
+import jenkins.plugins.git.GitSCMSource;
+import org.jenkinsci.plugins.workflow.steps.scm.GitSampleRepoRule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class NoTriggerBranchPropertyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @Issue("JENKINS-32396")
+    @Test
+    public void smokes() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "newfeature");
+        sampleRepo.write("stuff", "content");
+        sampleRepo.git("add", "stuff");
+        sampleRepo.git("commit", "--all", "--message=newfeature");
+        sampleRepo.git("checkout", "-b", "release", "master");
+        sampleRepo.write("server", "mycorp.com");
+        sampleRepo.git("add", "server");
+        sampleRepo.git("commit", "--all", "--message=release");
+        MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
+        BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
+        branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
+            new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
+        }));
+        stuff.getSourcesList().add(branchSource);
+        r.configRoundtrip(stuff);
+        stuff.scheduleBuild2(0).getFuture().get();
+        r.waitUntilNoActivity();
+        showComputation(stuff);
+        FreeStyleProject master = r.jenkins.getItemByFullName("stuff/master", FreeStyleProject.class);
+        assertNotNull(master);
+        assertEquals(2, master.getNextBuildNumber());
+        FreeStyleProject release = r.jenkins.getItemByFullName("stuff/release", FreeStyleProject.class);
+        assertNotNull(release);
+        assertEquals(1, release.getNextBuildNumber());
+        FreeStyleProject newfeature = r.jenkins.getItemByFullName("stuff/newfeature", FreeStyleProject.class);
+        assertNotNull(newfeature);
+        assertEquals(2, newfeature.getNextBuildNumber());
+        sampleRepo.git("checkout", "master");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=master-2");
+        sampleRepo.git("checkout", "newfeature");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=newfeature-2");
+        sampleRepo.git("checkout", "release");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=release-2");
+        sampleRepo.notifyCommit(r);
+        showComputation(stuff);
+        assertEquals(3, master.getNextBuildNumber());
+        assertEquals(1, release.getNextBuildNumber());
+        assertEquals(3, newfeature.getNextBuildNumber());
+        QueueTaskFuture<FreeStyleBuild> releaseBuild = release.scheduleBuild2(0);
+        assertNotNull("was able to schedule a manual build of the release branch", releaseBuild);
+        assertEquals(1, releaseBuild.get().getNumber());
+        assertEquals(2, release.getNextBuildNumber());
+    }
+
+    static void showComputation(@NonNull ComputedFolder<?> d) throws Exception {
+        FolderComputation<?> computation = d.getComputation();
+        System.out.println("---%<--- " + computation.getUrl());
+        computation.writeWholeLogTo(System.out);
+        System.out.println("---%<--- ");
+    }
+
+}

--- a/src/test/java/jenkins/branch/NoTriggerOrganizationFolderPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerOrganizationFolderPropertyTest.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.queue.QueueTaskFuture;
+import java.util.Collections;
+import jenkins.branch.harness.MultiBranchImpl;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.impl.SingleSCMNavigator;
+import org.jenkinsci.plugins.workflow.steps.scm.GitSampleRepoRule;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class NoTriggerOrganizationFolderPropertyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @Issue("JENKINS-32396")
+    @Test
+    public void smokes() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "newfeature");
+        sampleRepo.write("stuff", "content");
+        sampleRepo.git("add", "stuff");
+        sampleRepo.git("commit", "--all", "--message=newfeature");
+        sampleRepo.git("checkout", "-b", "release", "master");
+        sampleRepo.write("server", "mycorp.com");
+        sampleRepo.git("add", "server");
+        sampleRepo.git("commit", "--all", "--message=release");
+        OrganizationFolder top = r.jenkins.createProject(OrganizationFolder.class, "top");
+        r.configRoundtrip(top);
+        NoTriggerOrganizationFolderProperty prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
+        assertNotNull(prop);
+        assertEquals(".*", prop.getBranches());
+        top.getProperties().replace(new NoTriggerOrganizationFolderProperty("(?!release.*).*"));
+        top.getProjectFactories().add(new OrganizationFolderTest.MockFactory());
+        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false))));
+        r.configRoundtrip(top);
+        prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
+        assertNotNull(prop);
+        assertEquals("(?!release.*).*", prop.getBranches());
+        assertEquals(1, top.getProperties().getAll(NoTriggerOrganizationFolderProperty.class).size());
+        top.scheduleBuild2(0).getFuture().get();
+        r.waitUntilNoActivity();
+        NoTriggerBranchPropertyTest.showComputation(top);
+        MultiBranchImpl stuff = r.jenkins.getItemByFullName("top/stuff", MultiBranchImpl.class);
+        assertNotNull(stuff);
+        NoTriggerBranchPropertyTest.showComputation(stuff);
+        FreeStyleProject master = r.jenkins.getItemByFullName("top/stuff/master", FreeStyleProject.class);
+        assertNotNull(master);
+        assertEquals(2, master.getNextBuildNumber());
+        FreeStyleProject release = r.jenkins.getItemByFullName("top/stuff/release", FreeStyleProject.class);
+        assertNotNull(release);
+        assertEquals(1, release.getNextBuildNumber());
+        FreeStyleProject newfeature = r.jenkins.getItemByFullName("top/stuff/newfeature", FreeStyleProject.class);
+        assertNotNull(newfeature);
+        assertEquals(2, newfeature.getNextBuildNumber());
+        sampleRepo.git("checkout", "master");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=master-2");
+        sampleRepo.git("checkout", "newfeature");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=newfeature-2");
+        sampleRepo.git("checkout", "release");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=release-2");
+        sampleRepo.notifyCommit(r);
+        NoTriggerBranchPropertyTest.showComputation(top);
+        NoTriggerBranchPropertyTest.showComputation(stuff);
+        assertEquals(3, master.getNextBuildNumber());
+        assertEquals(1, release.getNextBuildNumber());
+        assertEquals(3, newfeature.getNextBuildNumber());
+        QueueTaskFuture<FreeStyleBuild> releaseBuild = release.scheduleBuild2(0);
+        assertNotNull("was able to schedule a manual build of the release branch", releaseBuild);
+        assertEquals(1, releaseBuild.get().getNumber());
+        assertEquals(2, release.getNextBuildNumber());
+    }
+
+    @TestExtension
+    public static class ConfigRoundTripDescriptor extends OrganizationFolderTest.MockFactoryDescriptor {}
+
+}

--- a/src/test/java/jenkins/branch/harness/BranchProjectFactoryImpl.java
+++ b/src/test/java/jenkins/branch/harness/BranchProjectFactoryImpl.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch.harness;
+
+import hudson.Extension;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import java.io.IOException;
+import jenkins.branch.Branch;
+import jenkins.branch.BranchProjectFactory;
+import jenkins.branch.BranchProjectFactoryDescriptor;
+import jenkins.branch.MultiBranchProject;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class BranchProjectFactoryImpl extends BranchProjectFactory<FreeStyleProject, FreeStyleBuild> {
+
+    @DataBoundConstructor
+    public BranchProjectFactoryImpl() {}
+
+    @Override
+    public FreeStyleProject newInstance(Branch branch) {
+        FreeStyleProject job = new FreeStyleProject(getOwner(), branch.getName());
+        setBranch(job, branch);
+        return job;
+    }
+
+    @Override
+    public Branch getBranch(FreeStyleProject project) {
+        return project.getProperty(BranchProperty.class).getBranch();
+    }
+
+    @Override
+    public FreeStyleProject setBranch(FreeStyleProject project, Branch branch) {
+        try {
+            project.addProperty(new BranchProperty(branch));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return project;
+    }
+
+    @Override
+    public boolean isProject(Item item) {
+        return item instanceof FreeStyleProject && ((FreeStyleProject) item).getProperty(BranchProperty.class) != null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BranchProjectFactoryDescriptor {
+
+        @Override
+        public boolean isApplicable(Class<? extends MultiBranchProject> clazz) {
+            return MultiBranchProject.class.isAssignableFrom(clazz);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "BranchProjectFactoryImpl";
+        }
+
+    }
+
+}

--- a/src/test/java/jenkins/branch/harness/MultiBranchImpl.java
+++ b/src/test/java/jenkins/branch/harness/MultiBranchImpl.java
@@ -24,16 +24,13 @@
 
 package jenkins.branch.harness;
 
-import java.io.IOException;
 import java.util.logging.Logger;
 
 import hudson.Extension;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
-import jenkins.branch.Branch;
 import jenkins.branch.BranchProjectFactory;
 import jenkins.branch.MultiBranchProject;
 import jenkins.branch.MultiBranchProjectDescriptor;
@@ -55,37 +52,6 @@ public class MultiBranchImpl extends MultiBranchProject<FreeStyleProject, FreeSt
     public boolean scheduleBuild() {
         LOGGER.info("Indexing multibranch project: " + getDisplayName());
         return super.scheduleBuild();
-    }
-
-    public static class BranchProjectFactoryImpl extends BranchProjectFactory<FreeStyleProject, FreeStyleBuild> {
-
-        @Override
-        public FreeStyleProject newInstance(Branch branch) {
-            FreeStyleProject job = new FreeStyleProject(getOwner(), branch.getName());
-            setBranch(job, branch);
-            return job;
-        }
-
-        @Override
-        public Branch getBranch(FreeStyleProject project) {
-            return project.getProperty(BranchProperty.class).getBranch();
-        }
-
-        @Override
-        public FreeStyleProject setBranch(FreeStyleProject project, Branch branch) {
-            try {
-                project.addProperty(new BranchProperty(branch));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            return project;
-        }
-
-        @Override
-        public boolean isProject(Item item) {
-            return item instanceof FreeStyleProject && ((FreeStyleProject) item).getProperty(BranchProperty.class) != null;
-        }
-
     }
 
     @Extension


### PR DESCRIPTION
[JENKINS-32396](https://issues.jenkins-ci.org/browse/JENKINS-32396)

Supersedes #1, from which it mostly borrows the branch property system (though with a different mechanism for actually suppressing the build).

![branch-sources](https://cloud.githubusercontent.com/assets/154109/15409544/2ed0dfc4-1de3-11e6-868b-3978a6de6fca.png)

I debated various approaches for extending the feature to organization folders and could not come up with a very satisfactory answer, so I went with this relatively straightforward system of using a folder property, which seems to work well enough.

![org-folder](https://cloud.githubusercontent.com/assets/154109/15409548/3481122c-1de3-11e6-9adc-0cd265ecb58f.png)

The question is whether there is a more general need for defining branch property strategies at the organization folder level. For example, you could imagine a `BranchPropertyStrategyFactory` bound to an `OrganizationFolder` which would define a `BranchPropertyStrategy` on each `BranchSource` in each `MultiBranchProject` child. A simple implementation could simply embed a `BranchPropertyStrategy` which it would apply to all children. This would not be hard to write. The problem is the GUI configuration: without rather complicated API changes (which other plugins would then need to implement), there is no way for this section in the configuration form of the `OrganizationFolder` to know which kinds of `MultiBranchProject`s and `SCMSource`s it might encounter after indexing. Thus it would have to show all `BranchPropertyDescriptor`s. This could be quite confusing; for example, if you had only `workflow-multibranch` installed and were expecting to use only `WorkflowMultiBranchProject`s, which previously accepted _no_ `BranchProperty`s and now will accept only `NoTriggerBranchProperty`, at the organization folder level you would still be prompted to configure things like `UntrustedBranchProperty` which will not work with multibranch Pipelines, as well as things like `BuildRetentionBranchProperty` which are not wanted (supplanted by the `properties` step).

Originally I considered using [JENKINS-34005](https://issues.jenkins-ci.org/browse/JENKINS-34005) and retrofitting the branch indexing trigger to be a true `Trigger`:

```groovy
properties([[$class: 'TriggersProperty', triggers: [[$class: 'BranchIndexingTrigger']]]])
```

or similar. But then every `Jenkinsfile` which you would want to build on commits would need to opt in, which seems weird (and would be incompatible). And it would be incompatible for other multibranch project types without some extra effort. Worst, the *first* build would not get run automatically for any given branch, which may be only an annoyance for `master` but would be a disaster for `PR-1234`.

Another option would be a `JobProperty` that suppresses the branch trigger, rather than a branch property, which would solve the default behavior issue and let you write something like

```groovy
if (!env.BRANCH_NAME.matches('release.*')) {
  properties([[$class: 'NoBranchIndexingTrigger']])
}
```

But this would suffer from the reverse first build problem: *all* branch projects would automatically run the first build, and the above snippet would only disable running *subsequent* builds upon commit. For some use cases this would be OK, but some users legitimately want to completely suppress all automatic builds of certain branches.

@reviewbybees esp. @stephenc