### PR TITLE
[JENKINS-32253] replace slash symbols ('/') with double underscores ('__')

### DIFF
--- a/src/main/java/jenkins/branch/Branch.java
+++ b/src/main/java/jenkins/branch/Branch.java
@@ -99,7 +99,15 @@ public class Branch {
      * @since 0.2-beta-7
      */
     public String getEncodedName() {
-        return Util.rawEncode(getName());
+        return this.encodeBranchName(getName());
+    }
+
+    /**
+     * Get a branch name with backslach symbol replaced with "__"
+     * @return with URL-unsafe characters escaped and slash symbols replaced with underscores
+     */
+    protected String encodeBranchName(String branchName) {
+        return Util.rawEncode(branchName).replace("%2F","___");
     }
 
     /**


### PR DESCRIPTION
replace slash symbols ('/') with double underscores ('__') in branch names to fix problems with encoded slashes in pathname (%2F) that corrupt msbuild and some other command line tools

It is a quick workaround that worked for me. Not sure, if it follows development process, if not, please give me a link to guide.

