### PR TITLE
Jenkins 34564 - Provide alternate branch encodings

### DIFF
--- a/src/main/java/jenkins/branch/Branch.java
+++ b/src/main/java/jenkins/branch/Branch.java
@@ -23,35 +23,23 @@
  */
 package jenkins.branch;
 
-import hudson.Extension;
-import hudson.ExtensionPoint;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
-import hudson.model.Descriptor;
-import hudson.model.Descriptor.FormException;
 import hudson.scm.NullSCM;
 import hudson.scm.SCM;
-import hudson.scm.SCMDescriptor;
 
 import javax.xml.bind.DatatypeConverter;
 
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import jenkins.model.GlobalConfiguration;
-import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.impl.NullSCMSource;
-import net.sf.json.JSONObject;
 
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * A source code branch.
@@ -87,7 +75,6 @@ public class Branch extends AbstractDescribableImpl<Branch> {
      * @param head     the name of the branch.
      * @param scm      the {@link SCM} for the branch.
      */
-    @DataBoundConstructor
     public Branch(String sourceId, SCMHead head, SCM scm, List<? extends BranchProperty> properties) {
         this.sourceId = sourceId;
         this.head = head;

--- a/src/main/java/jenkins/branch/Branch.java
+++ b/src/main/java/jenkins/branch/Branch.java
@@ -120,6 +120,9 @@ public class Branch extends AbstractDescribableImpl<Branch> {
      */
     public String getEncodedName() {
         BranchGlobalDescriptor descriptor =  GlobalConfiguration.all().get(BranchGlobalDescriptor.class);
+        if (null == descriptor) {
+            throw new IllegalStateException("BranchGlobalDescriptor should always be available as it is included in this plugin");
+        }
 
         try {
             switch (descriptor.getPathEncodingType()) {

--- a/src/main/java/jenkins/branch/BranchGlobalDescriptor.java
+++ b/src/main/java/jenkins/branch/BranchGlobalDescriptor.java
@@ -30,8 +30,6 @@ import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
 
-import java.util.logging.Logger;
-
 enum PathEncoding {
     DEFAULT, BASE64, STRIP
 };

--- a/src/main/java/jenkins/branch/BranchGlobalDescriptor.java
+++ b/src/main/java/jenkins/branch/BranchGlobalDescriptor.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, IBM, Inc., Alastair D'Silva.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+import hudson.Extension;
+
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+
+import java.util.logging.Logger;
+
+enum PathEncoding {
+    DEFAULT, BASE64, STRIP
+};
+
+@Extension
+public class BranchGlobalDescriptor extends GlobalConfiguration {
+
+    // @Extension
+    // public static final class DescriptorImpl extends Descriptor<Branch> {
+
+    /**
+     * Which path encoding to use
+     */
+    private PathEncoding pathEncoding = PathEncoding.DEFAULT;
+
+    public BranchGlobalDescriptor() {
+        super();
+        load();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json.getJSONObject("branchAPI"));
+        save();
+        return true;
+    }
+
+    /**
+     * Get the display name for this descriptor
+     *
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return Messages.DisplayName();
+    }
+
+    /**
+     * Get the currently selected path encoding
+     *
+     * @return the currently selected path encoding
+     */
+    public String getPathEncoding() {
+        return pathEncoding.name();
+    }
+
+    /**
+     * Get the enum value of the path encoding
+     *
+     * @return the path encoding
+     */
+    public PathEncoding getPathEncodingType() {
+        return pathEncoding;
+    }
+
+    /**
+     * Select the encoding to use to convert branch names to paths
+     */
+    public void setPathEncoding(String encoding) {
+        pathEncoding = PathEncoding.valueOf(encoding);
+    }
+
+}

--- a/src/main/resources/jenkins/branch/BranchGlobalDescriptor/config.jelly
+++ b/src/main/resources/jenkins/branch/BranchGlobalDescriptor/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:section title="Branch API plugin" name="branchAPI">
+    <f:entry title="Path Encoding" field="pathEncoding">
+      <select name="pathEncoding">
+        <f:option value="DEFAULT" selected="${descriptor.pathEncoding == 'DEFAULT'}">Default</f:option>
+        <f:option value="BASE64" selected="${descriptor.pathEncoding == 'BASE64'}">Base64</f:option>
+        <f:option value="STRIP" selected="${descriptor.pathEncoding == 'STRIP'}">Strip</f:option>
+      </select>
+    </f:entry>
+  </f:section>
+</j:jelly>
+

--- a/src/main/resources/jenkins/branch/BranchGlobalDescriptor/help-pathEncoding.html
+++ b/src/main/resources/jenkins/branch/BranchGlobalDescriptor/help-pathEncoding.html
@@ -1,0 +1,9 @@
+<div>
+    Choose how branch names are encoded on disk:
+    <ul>
+        <li>Default: The legacy encoding, using URL encoding. Note that this may cause problems in some projects, as special characters are encoded with '%', which may have special meanings (eg. in Makefiles).</li>
+        <li>Base64: The branch name is Base64 encoded. This is always safe, but the directory name is not human readable.</li>
+        <li>Strip: A variant of URL encoding, with special characters replaced with underscores.</li>
+    </ul>
+    <strong>Warning: Changing this value will require projects that utilize the Branch API to be reindexed, eg. Multibranch Project & Multibranch Pipeline projects. This will cause history to be lost if the encoded branch name changes.</strong>
+</div>

--- a/src/main/resources/jenkins/branch/Messages.properties
+++ b/src/main/resources/jenkins/branch/Messages.properties
@@ -36,3 +36,4 @@ RateLimitBranchProperty.duration.day=Day
 RateLimitBranchProperty.duration.week=Week
 RateLimitBranchProperty.duration.month=Month
 RateLimitBranchProperty.duration.year=Year
+DisplayName=Branch API


### PR DESCRIPTION
The default branch encoding method adds '%' to the directory names.

This is problematic as this character has special meanings in some situations (eg. % is a wildcard in makefiles).

This pull request adds alternate encoding methods which do not add special characters:
- Base64 encoding
- Strip encoding, URL encoded, forward slashes replaced with underscore, % replaced with double underscore, underscore replaced with triple underscore