### PR TITLE
[JENKINS-37263] Force remote checkout

### DIFF
--- a/src/main/java/jenkins/branch/Branch.java
+++ b/src/main/java/jenkins/branch/Branch.java
@@ -194,6 +194,10 @@ public class Branch {
         return result;
     }
 
+    public String getRemoteName() {
+        return "refs/heads/" + head.getName();
+    }
+
     /**
      * Represents a dead branch.
      */


### PR DESCRIPTION
## Description of the problem

I've a multibranch pipeline project configured with the local branch extension and many branch following the git flow model (features/xxxx). When I push a commit on the feature branch, this commit is detected by Jenkins, and pulled by the master to read the Jenkinsfile. The first time it works, but after that, the local branch is selected instead of the remote branch, amd the new commits are not fetch. The bug only occurs on branches with a slash in their names.

## Investigation

I've connected my debugger to my Jenkins installation. It appears that Jenkins has detected 2 branches matching the name. One local and one remote. The local one is created by the local branch git extension.

I can't explicitly specify to Jenkins to use the remote one because I use the pipeline plugin, and this checkout is made automatically to retrieve the Jenkinsfile. So, the git implementation takes the first one, which is generally the local branch which is not yet updated...

```java
Revision marked = candidates.iterator().next();
```

## Logs

```
16:10:31 Multiple candidate revisions
16:10:31 Checking out Revision 604398f062b459c797f31d6c13b568dd7612362d (features/my-feature-branch)
16:10:31  > git.exe config core.sparsecheckout # timeout=30
16:10:31  > git.exe checkout -f 604398f062b459c797f31d6c13b568dd7612362d # timeout=120
16:10:32  > git.exe branch -a -v --no-abbrev # timeout=30
16:10:32  > git.exe branch -D features/my-feature-branch # timeout=30
16:10:32  > git.exe checkout -b features/my-feature-branch 604398f062b459c797f31d6c13b568dd7612362d # timeout=120
16:10:32  > git.exe rev-list 0fa6b0371aa1e77a35acdc9f82bb68bb2c32fb2d # timeout=30
```

## How to reproduce it

 * Create a new repository and initialize it (on github, with a README.md for example)
 * Clone it on your computer:
```
git clone https://lausivoiduts.visualstudio.com/QuarahMC/_git/JENKINS-37263
cd JENKINS-37263
```
 * Create a new branch:
```
git checkout -b features/this-bug
```
 * Add something in the Jenkinsfile:
```
echo "echo 'first commit' " > Jenkinsfile
```
 * Commit and push it:
```
git add Jenkinfile
git commit -m "first commit" 
git push --set-upstream origin features/this-bug
```
 * Add a new Multibranch Pipeline Project in Jenkins, add as Source your git repository.
    Click on "Add Behaviour", select "Checkout to a local branch".
    Set its value to "**" (without the quotes).
    Validate it.
 * Check that the branch was built, and the message "first commit" appears in the log
 * Modify your Jenkinsfile:
```
echo "echo 'second commit' " > Jenkinsfile
```
 * Commit and push it:
```
git add Jenkinfile
git commit -m "second commit"
git push
```
 * Run the branch indexing
 * Check that the branch is built. Check the log, you'll see "first commit" instead of "second commit".

## Proposed fix

Initialize the new project with `ref/heads/features/my-branch` instead of `features/my-branch`.
This fix could be not compatible with other VCS. I'm open to suggestions to improve it.

## Links
[Associated issue on JIRA](https://issues.jenkins-ci.org/browse/JENKINS-37263)