### PR TITLE
[JENKINS-37219] Add a job property for overriding branch index triggers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.625.1</jenkins.version>
+    <jenkins.version>1.642.3</jenkins.version>
   </properties>
 
   <repositories>
@@ -92,6 +92,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
       <version>5.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.4-SNAPSHOT</version>
+      <version>1.4</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -71,19 +71,19 @@ public class NoTriggerBranchProperty extends BranchProperty {
                     for (Cause c : ((CauseAction) action).getCauses()) {
                         if (c instanceof BranchIndexingCause) {
                             if (p instanceof Job) {
-                                Job j = (Job) p;
+                                Job<?,?> j = (Job) p;
                                 if (j.getParent() instanceof MultiBranchProject) {
 
-                                    OverrideIndexTriggersJobProperty overrideProp =
-                                            (OverrideIndexTriggersJobProperty) j.getProperty(OverrideIndexTriggersJobProperty.class);
-
-                                    for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
-                                        if (prop instanceof NoTriggerBranchProperty
-                                                && (overrideProp == null || !overrideProp.getEnableTriggers())) {
-                                            return false;
+                                    OverrideIndexTriggersJobProperty overrideProp = j.getProperty(OverrideIndexTriggersJobProperty.class);
+                                    if (overrideProp != null) {
+                                        return overrideProp.getEnableTriggers();
+                                    } else {
+                                        for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
+                                            if (prop instanceof NoTriggerBranchProperty) {
+                                                return false;
+                                            }
                                         }
                                     }
-
                                 }
                             }
                         }

--- a/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
@@ -90,6 +90,9 @@ public class NoTriggerOrganizationFolderProperty extends AbstractFolderProperty<
                         if (c instanceof BranchIndexingCause) {
                             if (p instanceof Job) {
                                 Job j = (Job) p;
+                                OverrideIndexTriggersJobProperty overrideProp =
+                                        (OverrideIndexTriggersJobProperty) j.getProperty(OverrideIndexTriggersJobProperty.class);
+
                                 if (j.getParent() instanceof MultiBranchProject) {
                                     MultiBranchProject mbp = (MultiBranchProject) j.getParent();
                                     if (mbp.getParent() instanceof OrganizationFolder) {
@@ -97,7 +100,8 @@ public class NoTriggerOrganizationFolderProperty extends AbstractFolderProperty<
                                         if (prop != null) {
                                             // Not necessarily the same as j.getName(), which may be encoded:
                                             String name = mbp.getProjectFactory().getBranch(j).getName();
-                                            if (!name.matches(prop.getBranches())) {
+                                            if (!name.matches(prop.getBranches()) &&
+                                                    (overrideProp == null || !overrideProp.getEnableTriggers())) {
                                                 return false;
                                             }
                                         }

--- a/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
@@ -89,20 +89,22 @@ public class NoTriggerOrganizationFolderProperty extends AbstractFolderProperty<
                     for (Cause c : ((CauseAction) action).getCauses()) {
                         if (c instanceof BranchIndexingCause) {
                             if (p instanceof Job) {
-                                Job j = (Job) p;
-                                OverrideIndexTriggersJobProperty overrideProp =
-                                        (OverrideIndexTriggersJobProperty) j.getProperty(OverrideIndexTriggersJobProperty.class);
+                                Job<?,?> j = (Job) p;
 
                                 if (j.getParent() instanceof MultiBranchProject) {
-                                    MultiBranchProject mbp = (MultiBranchProject) j.getParent();
-                                    if (mbp.getParent() instanceof OrganizationFolder) {
-                                        NoTriggerOrganizationFolderProperty prop = ((OrganizationFolder) mbp.getParent()).getProperties().get(NoTriggerOrganizationFolderProperty.class);
-                                        if (prop != null) {
-                                            // Not necessarily the same as j.getName(), which may be encoded:
-                                            String name = mbp.getProjectFactory().getBranch(j).getName();
-                                            if (!name.matches(prop.getBranches()) &&
-                                                    (overrideProp == null || !overrideProp.getEnableTriggers())) {
-                                                return false;
+                                    OverrideIndexTriggersJobProperty overrideProp = j.getProperty(OverrideIndexTriggersJobProperty.class);
+                                    if (overrideProp != null) {
+                                        return overrideProp.getEnableTriggers();
+                                    } else {
+                                        MultiBranchProject mbp = (MultiBranchProject) j.getParent();
+                                        if (mbp.getParent() instanceof OrganizationFolder) {
+                                            NoTriggerOrganizationFolderProperty prop = ((OrganizationFolder) mbp.getParent()).getProperties().get(NoTriggerOrganizationFolderProperty.class);
+                                            if (prop != null) {
+                                                // Not necessarily the same as j.getName(), which may be encoded:
+                                                String name = mbp.getProjectFactory().getBranch(j).getName();
+                                                if (!name.matches(prop.getBranches())) {
+                                                    return false;
+                                                }
                                             }
                                         }
                                     }

--- a/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
+++ b/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
@@ -64,7 +64,7 @@ public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
         }
 
         @Override public String getDisplayName() {
-            return "Override multibranch or organization branch indexing triggers setting.";
+            return "Override multibranch or organization branch indexing triggers.";
         }
 
         @Override

--- a/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
+++ b/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package jenkins.branch;
 
 import hudson.Extension;
@@ -29,35 +28,49 @@ import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
 import hudson.model.Queue;
-import hudson.model.Run;
-import java.util.List;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.List;
 
 /**
- * Suppresses builds due to {@link BranchIndexingCause}.
+ * Allows overriding indexing triggers for an individual job - either by enabling when the multibranch or org is set to
+ * suppress them, or disabling if they're otherwise enabled.
  */
-@Restricted(NoExternalUse.class)
-public class NoTriggerBranchProperty extends BranchProperty {
+public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
+    private boolean enableTriggers;
 
     @DataBoundConstructor
-    public NoTriggerBranchProperty() {}
+    public OverrideIndexTriggersJobProperty(boolean enableTriggers) {
+        this.enableTriggers = enableTriggers;
+    }
 
-    @Override
-    public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
-        return null;
+    public boolean getEnableTriggers() {
+        return enableTriggers;
     }
 
     @Extension
-    public static class DescriptorImpl extends BranchPropertyDescriptor {
+    @Symbol("overrideIndexTriggers")
+    public static class DescriptorImpl extends JobPropertyDescriptor {
 
-        @Override
-        public String getDisplayName() {
-            return Messages.NoTriggerBranchProperty_suppress_automatic_scm_triggering();
+        @Override public String getDisplayName() {
+            return "Override multibranch or organization branch indexing triggers setting.";
         }
 
+        @Override
+        public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return formData.optBoolean("specified") ? super.newInstance(req, formData) : null;
+        }
+
+    }
+
+    public boolean isOwnerMultibranch() {
+        return owner.getParent() instanceof MultiBranchProject;
     }
 
     @Extension
@@ -66,24 +79,16 @@ public class NoTriggerBranchProperty extends BranchProperty {
         @SuppressWarnings({"unchecked", "rawtypes"}) // untypable
         @Override
         public boolean shouldSchedule(Queue.Task p, List<Action> actions) {
-            for (Action action :  actions) {
+            for (Action action : actions) {
                 if (action instanceof CauseAction) {
                     for (Cause c : ((CauseAction) action).getCauses()) {
                         if (c instanceof BranchIndexingCause) {
                             if (p instanceof Job) {
                                 Job j = (Job) p;
-                                if (j.getParent() instanceof MultiBranchProject) {
-
-                                    OverrideIndexTriggersJobProperty overrideProp =
-                                            (OverrideIndexTriggersJobProperty) j.getProperty(OverrideIndexTriggersJobProperty.class);
-
-                                    for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
-                                        if (prop instanceof NoTriggerBranchProperty
-                                                && (overrideProp == null || !overrideProp.getEnableTriggers())) {
-                                            return false;
-                                        }
-                                    }
-
+                                OverrideIndexTriggersJobProperty overrideProp =
+                                        (OverrideIndexTriggersJobProperty) j.getProperty(OverrideIndexTriggersJobProperty.class);
+                                if (overrideProp != null && !overrideProp.getEnableTriggers()) {
+                                    return false;
                                 }
                             }
                         }
@@ -94,5 +99,6 @@ public class NoTriggerBranchProperty extends BranchProperty {
         }
 
     }
+
 
 }

--- a/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
+++ b/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
@@ -44,7 +44,7 @@ import java.util.List;
  * suppress them, or disabling if they're otherwise enabled.
  */
 public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
-    private boolean enableTriggers;
+    private final boolean enableTriggers;
 
     @DataBoundConstructor
     public OverrideIndexTriggersJobProperty(boolean enableTriggers) {
@@ -84,11 +84,12 @@ public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
                     for (Cause c : ((CauseAction) action).getCauses()) {
                         if (c instanceof BranchIndexingCause) {
                             if (p instanceof Job) {
-                                Job j = (Job) p;
-                                OverrideIndexTriggersJobProperty overrideProp =
-                                        (OverrideIndexTriggersJobProperty) j.getProperty(OverrideIndexTriggersJobProperty.class);
-                                if (overrideProp != null && !overrideProp.getEnableTriggers()) {
-                                    return false;
+                                Job<?,?> j = (Job) p;
+                                OverrideIndexTriggersJobProperty overrideProp = j.getProperty(OverrideIndexTriggersJobProperty.class);
+                                if (overrideProp != null) {
+                                    return overrideProp.getEnableTriggers();
+                                } else {
+                                    return true;
                                 }
                             }
                         }

--- a/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
+++ b/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
@@ -59,8 +59,8 @@ public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
     @Symbol("overrideIndexTriggers")
     public static class DescriptorImpl extends JobPropertyDescriptor {
 
-        public boolean isOwnerMultibranch(Job<?,?> owner) {
-            return owner.getParent() instanceof MultiBranchProject;
+        public boolean isOwnerMultibranch(Item item) {
+            return item instanceof MultiBranchProject || item instanceof OrganizationFolder || item.getParent() instanceof MultiBranchProject;
         }
 
         @Override public String getDisplayName() {

--- a/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
+++ b/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
@@ -27,6 +27,7 @@ import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
@@ -58,6 +59,10 @@ public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
     @Symbol("overrideIndexTriggers")
     public static class DescriptorImpl extends JobPropertyDescriptor {
 
+        public boolean isOwnerMultibranch(Job<?,?> owner) {
+            return owner.getParent() instanceof MultiBranchProject;
+        }
+
         @Override public String getDisplayName() {
             return "Override multibranch or organization branch indexing triggers setting.";
         }
@@ -66,11 +71,6 @@ public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
         public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             return formData.optBoolean("specified") ? super.newInstance(req, formData) : null;
         }
-
-    }
-
-    public boolean isOwnerMultibranch() {
-        return owner.getParent() instanceof MultiBranchProject;
     }
 
     @Extension

--- a/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
+++ b/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <j:if test="${descriptor.isOwnerMultibranch(it)}">
         <f:block>
             <f:optionalBlock title="${descriptor.displayName}" name="specified" checked="${instance != null}" inline="true">
-                <f:entry title="${%Select to enable index triggers despite overrides. Unselect to disable index triggers regardless of overrides.}"
+                <f:entry title="${%Override disabled triggers}"
                          field="enableTriggers">
                     <f:checkbox />
                 </f:entry>

--- a/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
+++ b/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
@@ -26,13 +26,11 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <j:if test="${descriptor.isOwnerMultibranch(it)}">
-        <f:block>
-            <f:optionalBlock title="${descriptor.displayName}" name="specified" checked="${instance != null}" inline="true">
-                <f:entry title="${%Override disabled triggers}"
-                         field="enableTriggers">
-                    <f:checkbox />
-                </f:entry>
-            </f:optionalBlock>
-        </f:block>
+        <f:optionalBlock title="${descriptor.displayName}" name="specified" checked="${instance != null}" inline="true">
+            <f:entry title="${%Override disabled triggers}"
+                     field="enableTriggers">
+                <f:checkbox />
+            </f:entry>
+        </f:optionalBlock>
     </j:if>
 </j:jelly>

--- a/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
+++ b/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
@@ -25,9 +25,9 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-    <j:if test="${it.isOwnerMultibranch()}">
+    <j:if test="${descriptor.isOwnerMultibranch(it)}">
         <f:block>
-            <f:optionalBlock title="${descriptor.displayName}" name="specified" checked="${instance != null}" inline="true" help="${descriptor.helpFile}">
+            <f:optionalBlock title="${descriptor.displayName}" name="specified" checked="${instance != null}" inline="true">
                 <f:entry title="${%Select to enable index triggers despite overrides. Unselect to disable index triggers regardless of overrides.}"
                          field="enableTriggers">
                     <f:checkbox />

--- a/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
+++ b/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/config.jelly
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <j:if test="${it.isOwnerMultibranch()}">
+        <f:block>
+            <f:optionalBlock title="${descriptor.displayName}" name="specified" checked="${instance != null}" inline="true" help="${descriptor.helpFile}">
+                <f:entry title="${%Select to enable index triggers despite overrides. Unselect to disable index triggers regardless of overrides.}"
+                         field="enableTriggers">
+                    <f:checkbox />
+                </f:entry>
+            </f:optionalBlock>
+        </f:block>
+    </j:if>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/help.html
+++ b/src/main/resources/jenkins/branch/OverrideIndexTriggersJobProperty/help.html
@@ -1,0 +1,11 @@
+<div>
+    <p>
+        Allows overriding default treatment of branch indexing triggers.
+    </p>
+    <p>
+        If branch indexing triggers are disabled at the multibranch or organization label, selecting this will enable them for this job only.
+    </p>
+    <p>
+        Otherwise, leaving the checkbox unselected will disable branch indexing triggers for this job only.
+    </p>
+</div>

--- a/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
+++ b/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
@@ -1,0 +1,226 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
+import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.branch.harness.MultiBranchImpl;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.impl.SingleSCMNavigator;
+import org.jenkinsci.plugins.workflow.steps.scm.GitSampleRepoRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.util.Collections;
+
+import static jenkins.branch.NoTriggerBranchPropertyTest.showComputation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class OverrideIndexTriggersJobPropertyTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+    @Rule
+    public GitSampleRepoRule orgSampleRepo = new GitSampleRepoRule();
+
+    @Issue("JENKINS-37219")
+    @Test
+    public void overridesDisabledBranch() throws Exception {
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "newfeature");
+        sampleRepo.write("stuff", "content");
+        sampleRepo.git("add", "stuff");
+        sampleRepo.git("commit", "--all", "--message=newfeature");
+        sampleRepo.git("checkout", "-b", "release", "master");
+        sampleRepo.write("server", "mycorp.com");
+        sampleRepo.git("add", "server");
+        sampleRepo.git("commit", "--all", "--message=release");
+        MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
+        BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
+        branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
+            new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
+        }));
+        stuff.getSourcesList().add(branchSource);
+        r.configRoundtrip(stuff);
+        stuff.scheduleBuild2(0).getFuture().get();
+        r.waitUntilNoActivity();
+        showComputation(stuff);
+        FreeStyleProject master = r.jenkins.getItemByFullName("stuff/master", FreeStyleProject.class);
+        assertNotNull(master);
+        assertEquals(2, master.getNextBuildNumber());
+        FreeStyleProject release = r.jenkins.getItemByFullName("stuff/release", FreeStyleProject.class);
+        assertNotNull(release);
+        assertEquals(1, release.getNextBuildNumber());
+        FreeStyleProject newfeature = r.jenkins.getItemByFullName("stuff/newfeature", FreeStyleProject.class);
+        assertNotNull(newfeature);
+        assertEquals(2, newfeature.getNextBuildNumber());
+        sampleRepo.git("checkout", "master");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=master-2");
+        sampleRepo.git("checkout", "newfeature");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=newfeature-2");
+        sampleRepo.git("checkout", "release");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=release-2");
+        sampleRepo.notifyCommit(r);
+        showComputation(stuff);
+        assertEquals(3, master.getNextBuildNumber());
+        assertEquals(1, release.getNextBuildNumber());
+        assertEquals(3, newfeature.getNextBuildNumber());
+
+        // Now add the property and make sure a build will get triggered.
+        release.addProperty(new OverrideIndexTriggersJobProperty(true));
+        sampleRepo.git("checkout", "release");
+        sampleRepo.write("file", "even more");
+        sampleRepo.git("commit", "--all", "--message=release-3");
+        sampleRepo.notifyCommit(r);
+        showComputation(stuff);
+
+        FreeStyleBuild releaseBuild = release.getBuildByNumber(1);
+        assertNotNull("release branch build was not triggered by commit", releaseBuild);
+        assertEquals(1, releaseBuild.getNumber());
+        assertEquals(2, release.getNextBuildNumber());
+    }
+
+    @Issue("JENKINS-37219")
+    @Test
+    public void overridesDisabledOrg() throws Exception {
+        orgSampleRepo.init();
+        orgSampleRepo.git("checkout", "-b", "newfeature");
+        orgSampleRepo.write("stuff", "content");
+        orgSampleRepo.git("add", "stuff");
+        orgSampleRepo.git("commit", "--all", "--message=newfeature");
+        orgSampleRepo.git("checkout", "-b", "release", "master");
+        orgSampleRepo.write("server", "mycorp.com");
+        orgSampleRepo.git("add", "server");
+        orgSampleRepo.git("commit", "--all", "--message=release");
+        OrganizationFolder top = r.jenkins.createProject(OrganizationFolder.class, "top");
+        r.configRoundtrip(top);
+        NoTriggerOrganizationFolderProperty prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
+        assertNotNull(prop);
+        assertEquals(".*", prop.getBranches());
+        top.getProperties().replace(new NoTriggerOrganizationFolderProperty("(?!release.*).*"));
+        top.getProjectFactories().add(new OrganizationFolderTest.MockFactory());
+        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(null, orgSampleRepo.toString(), "", "*", "", false))));
+        r.configRoundtrip(top);
+        prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
+        assertNotNull(prop);
+        assertEquals("(?!release.*).*", prop.getBranches());
+        assertEquals(1, top.getProperties().getAll(NoTriggerOrganizationFolderProperty.class).size());
+        top.scheduleBuild2(0).getFuture().get();
+        r.waitUntilNoActivity();
+        showComputation(top);
+        MultiBranchImpl stuff = r.jenkins.getItemByFullName("top/stuff", MultiBranchImpl.class);
+        assertNotNull(stuff);
+        showComputation(stuff);
+        FreeStyleProject master = r.jenkins.getItemByFullName("top/stuff/master", FreeStyleProject.class);
+        assertNotNull(master);
+        assertEquals(2, master.getNextBuildNumber());
+        FreeStyleProject release = r.jenkins.getItemByFullName("top/stuff/release", FreeStyleProject.class);
+        assertNotNull(release);
+        assertEquals(1, release.getNextBuildNumber());
+        FreeStyleProject newfeature = r.jenkins.getItemByFullName("top/stuff/newfeature", FreeStyleProject.class);
+        assertNotNull(newfeature);
+        assertEquals(2, newfeature.getNextBuildNumber());
+        orgSampleRepo.git("checkout", "master");
+        orgSampleRepo.write("file", "more");
+        orgSampleRepo.git("commit", "--all", "--message=master-2");
+        orgSampleRepo.git("checkout", "newfeature");
+        orgSampleRepo.write("file", "more");
+        orgSampleRepo.git("commit", "--all", "--message=newfeature-2");
+        orgSampleRepo.git("checkout", "release");
+        orgSampleRepo.write("file", "more");
+        orgSampleRepo.git("commit", "--all", "--message=release-2");
+        orgSampleRepo.notifyCommit(r);
+        showComputation(top);
+        showComputation(stuff);
+        assertEquals(3, master.getNextBuildNumber());
+        assertEquals(1, release.getNextBuildNumber());
+        assertEquals(3, newfeature.getNextBuildNumber());
+
+        // Now add the property and make sure a build will get triggered.
+        release.addProperty(new OverrideIndexTriggersJobProperty(true));
+        orgSampleRepo.git("checkout", "release");
+        orgSampleRepo.write("file", "even more");
+        orgSampleRepo.git("commit", "--all", "--message=release-3");
+        orgSampleRepo.notifyCommit(r);
+        showComputation(top);
+        showComputation(stuff);
+
+        FreeStyleBuild releaseBuild = release.getBuildByNumber(1);
+        assertNotNull("release branch build was not triggered by commit", releaseBuild);
+        assertEquals(1, releaseBuild.getNumber());
+        assertEquals(2, release.getNextBuildNumber());
+    }
+
+    @Issue("JENKINS-37219")
+    @Test
+    public void overridesEnabled() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("stuff", "content");
+        sampleRepo.git("add", "stuff");
+        sampleRepo.git("commit", "--all", "--message=master-1");
+        MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
+        BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
+        stuff.getSourcesList().add(branchSource);
+        r.configRoundtrip(stuff);
+        stuff.scheduleBuild2(0).getFuture().get();
+        r.waitUntilNoActivity();
+        showComputation(stuff);
+        FreeStyleProject master = r.jenkins.getItemByFullName("stuff/master", FreeStyleProject.class);
+        assertNotNull(master);
+        assertEquals(2, master.getNextBuildNumber());
+
+        master.addProperty(new OverrideIndexTriggersJobProperty(false));
+        sampleRepo.git("checkout", "master");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=master-2");
+        sampleRepo.notifyCommit(r);
+        showComputation(stuff);
+        assertEquals(2, master.getNextBuildNumber());
+
+
+        QueueTaskFuture<FreeStyleBuild> masterBuild = master.scheduleBuild2(0);
+        assertNotNull("was not able to schedule a manual build of the master branch", masterBuild);
+        assertEquals(2, masterBuild.get().getNumber());
+        assertEquals(3, master.getNextBuildNumber());
+    }
+
+    @TestExtension
+    public static class ConfigRoundTripDescriptor extends OrganizationFolderTest.MockFactoryDescriptor {}
+
+}

--- a/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
+++ b/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
@@ -24,9 +24,6 @@
 
 package jenkins.branch;
 
-import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
-import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.queue.QueueTaskFuture;
@@ -53,8 +50,6 @@ public class OverrideIndexTriggersJobPropertyTest {
     public JenkinsRule r = new JenkinsRule();
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
-    @Rule
-    public GitSampleRepoRule orgSampleRepo = new GitSampleRepoRule();
 
     @Issue("JENKINS-37219")
     @Test
@@ -119,15 +114,15 @@ public class OverrideIndexTriggersJobPropertyTest {
     @Issue("JENKINS-37219")
     @Test
     public void overridesDisabledOrg() throws Exception {
-        orgSampleRepo.init();
-        orgSampleRepo.git("checkout", "-b", "newfeature");
-        orgSampleRepo.write("stuff", "content");
-        orgSampleRepo.git("add", "stuff");
-        orgSampleRepo.git("commit", "--all", "--message=newfeature");
-        orgSampleRepo.git("checkout", "-b", "release", "master");
-        orgSampleRepo.write("server", "mycorp.com");
-        orgSampleRepo.git("add", "server");
-        orgSampleRepo.git("commit", "--all", "--message=release");
+        sampleRepo.init();
+        sampleRepo.git("checkout", "-b", "newfeature");
+        sampleRepo.write("stuff", "content");
+        sampleRepo.git("add", "stuff");
+        sampleRepo.git("commit", "--all", "--message=newfeature");
+        sampleRepo.git("checkout", "-b", "release", "master");
+        sampleRepo.write("server", "mycorp.com");
+        sampleRepo.git("add", "server");
+        sampleRepo.git("commit", "--all", "--message=release");
         OrganizationFolder top = r.jenkins.createProject(OrganizationFolder.class, "top");
         r.configRoundtrip(top);
         NoTriggerOrganizationFolderProperty prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
@@ -135,7 +130,7 @@ public class OverrideIndexTriggersJobPropertyTest {
         assertEquals(".*", prop.getBranches());
         top.getProperties().replace(new NoTriggerOrganizationFolderProperty("(?!release.*).*"));
         top.getProjectFactories().add(new OrganizationFolderTest.MockFactory());
-        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(null, orgSampleRepo.toString(), "", "*", "", false))));
+        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false))));
         r.configRoundtrip(top);
         prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
         assertNotNull(prop);
@@ -156,16 +151,16 @@ public class OverrideIndexTriggersJobPropertyTest {
         FreeStyleProject newfeature = r.jenkins.getItemByFullName("top/stuff/newfeature", FreeStyleProject.class);
         assertNotNull(newfeature);
         assertEquals(2, newfeature.getNextBuildNumber());
-        orgSampleRepo.git("checkout", "master");
-        orgSampleRepo.write("file", "more");
-        orgSampleRepo.git("commit", "--all", "--message=master-2");
-        orgSampleRepo.git("checkout", "newfeature");
-        orgSampleRepo.write("file", "more");
-        orgSampleRepo.git("commit", "--all", "--message=newfeature-2");
-        orgSampleRepo.git("checkout", "release");
-        orgSampleRepo.write("file", "more");
-        orgSampleRepo.git("commit", "--all", "--message=release-2");
-        orgSampleRepo.notifyCommit(r);
+        sampleRepo.git("checkout", "master");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=master-2");
+        sampleRepo.git("checkout", "newfeature");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=newfeature-2");
+        sampleRepo.git("checkout", "release");
+        sampleRepo.write("file", "more");
+        sampleRepo.git("commit", "--all", "--message=release-2");
+        sampleRepo.notifyCommit(r);
         showComputation(top);
         showComputation(stuff);
         assertEquals(3, master.getNextBuildNumber());
@@ -174,10 +169,10 @@ public class OverrideIndexTriggersJobPropertyTest {
 
         // Now add the property and make sure a build will get triggered.
         release.addProperty(new OverrideIndexTriggersJobProperty(true));
-        orgSampleRepo.git("checkout", "release");
-        orgSampleRepo.write("file", "even more");
-        orgSampleRepo.git("commit", "--all", "--message=release-3");
-        orgSampleRepo.notifyCommit(r);
+        sampleRepo.git("checkout", "release");
+        sampleRepo.write("file", "even more");
+        sampleRepo.git("commit", "--all", "--message=release-3");
+        sampleRepo.notifyCommit(r);
         showComputation(top);
         showComputation(stuff);
 


### PR DESCRIPTION
[JENKINS-37219](https://issues.jenkins-ci.org/browse/JENKINS-37219)

Works in both directions - disables branch index triggers if set to
false, enables them if set to true and either there's a
NoTriggerBranchProperty applying to the branch or there's a
NoTriggerOrganizationFolderProperty applying to the organization.

Theoretically, the config shouldn't show up for any job type but
multibranch jobs, where it'll only show up in the Snippet Generator anyway.

https://github.com/jenkinsci/workflow-multibranch-plugin/pull/26 will be replaced with an integration test of this in the `properties` step.

cc @reviewbybees esp @jglick 