### PR TITLE
[JENKINS-34564] Safer workspace names for branch projects

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -49,7 +49,8 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         if (node instanceof Jenkins) {
             return ((Jenkins) node).getRootPath().child("workspace/" + minimized);
         } else if (node instanceof Slave) {
-            return ((Slave) node).getWorkspaceRoot().child(minimized);
+            FilePath root = ((Slave) node).getWorkspaceRoot();
+            return root != null ? root.child(minimized) : null;
         } else { // ?
             return null;
         }

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import com.google.common.hash.Hashing;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Node;
+import hudson.model.Slave;
+import hudson.model.TopLevelItem;
+import hudson.remoting.Base64;
+import jenkins.model.Jenkins;
+import jenkins.slaves.WorkspaceLocator;
+
+/**
+ * Chooses manageable workspace names for branch projects.
+ */
+@Extension
+public class WorkspaceLocatorImpl extends WorkspaceLocator {
+
+    @Override
+    public FilePath locate(TopLevelItem item, Node node) {
+        if (!(item.getParent() instanceof MultiBranchProject)) {
+            return null;
+        }
+        String minimized = minimize(item.getFullName());
+        if (node instanceof Jenkins) {
+            return ((Jenkins) node).getRootPath().child("workspace/" + minimized);
+        } else if (node instanceof Slave) {
+            return ((Slave) node).getWorkspaceRoot().child(minimized);
+        } else { // ?
+            return null;
+        }
+    }
+
+    static String minimize(String name) {
+        return name.replaceAll("(%[0-9A-F]{2}|[^a-zA-Z0-9-_.])+", "_").replaceFirst(".*?(.{0,36}$)", "$1") + "-" +
+            Base64.encode(Hashing.sha256().hashString(name).asBytes()).replace('/', '_').replace('+', '.').replaceFirst("=+$", "");
+    }
+
+}

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -46,7 +46,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @see "JENKINS-34564"
  */
 @Restricted(NoExternalUse.class)
-@Extension
+@Extension(ordinal = -100)
 public class WorkspaceLocatorImpl extends WorkspaceLocator {
 
     private static final Logger LOGGER = Logger.getLogger(WorkspaceLocatorImpl.class.getName());

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -75,7 +75,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
     }
 
     static String uniqueSuffix(String name) {
-        return "-" + Base64.encode(Hashing.sha256().hashString(name).asBytes()).
+        return Base64.encode(Hashing.sha256().hashString(name).asBytes()).
             replace('/', '_').
             replace('+', '.').
             replaceFirst("=+$", "");
@@ -85,7 +85,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         int maxMnemonic = Math.max(PATH_MAX - 44, 1);
         String result = name.replaceAll("(%[0-9A-F]{2}|[^a-zA-Z0-9-_.])+", "_").
             replaceFirst(".*?(.{0," + maxMnemonic + "}$)", "$1") +
-            uniqueSuffix(name);
+            "-" + uniqueSuffix(name);
         assert result.length() <= PATH_MAX : result + " does not fit inside " + PATH_MAX;
         return result;
     }
@@ -117,7 +117,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                     return;
                 }
                 for (FilePath child : root.listDirectories()) {
-                    if (child.getName().endsWith(suffix)) {
+                    if (child.getName().contains(suffix)) {
                         LOGGER.log(Level.INFO, "deleting obsolete workspace {0} on {1}", new Object[] {child, node.getNodeName()});
                         child.deleteRecursive();
                     }

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -27,18 +27,29 @@ package jenkins.branch;
 import com.google.common.hash.Hashing;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.Item;
 import hudson.model.Node;
 import hudson.model.Slave;
 import hudson.model.TopLevelItem;
+import hudson.model.listeners.ItemListener;
 import hudson.remoting.Base64;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.slaves.WorkspaceLocator;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Chooses manageable workspace names for branch projects.
+ * @see "JENKINS-34564"
  */
+@Restricted(NoExternalUse.class)
 @Extension
 public class WorkspaceLocatorImpl extends WorkspaceLocator {
+
+    private static final Logger LOGGER = Logger.getLogger(WorkspaceLocatorImpl.class.getName());
 
     /** The most characters to allow in a workspace directory name, relative to the root. Zero to disable altogether. */
     @SuppressWarnings("FieldMayBeFinal")
@@ -63,12 +74,59 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         }
     }
 
+    static String uniqueSuffix(String name) {
+        return "-" + Base64.encode(Hashing.sha256().hashString(name).asBytes()).
+            replace('/', '_').
+            replace('+', '.').
+            replaceFirst("=+$", "");
+    }
+
     static String minimize(String name) {
-        String uniqueSuffix = "-" + Base64.encode(Hashing.sha256().hashString(name).asBytes()).replace('/', '_').replace('+', '.').replaceFirst("=+$", "");
         int maxMnemonic = Math.max(PATH_MAX - 44, 1);
-        String result = name.replaceAll("(%[0-9A-F]{2}|[^a-zA-Z0-9-_.])+", "_").replaceFirst(".*?(.{0," + maxMnemonic + "}$)", "$1") + uniqueSuffix;
+        String result = name.replaceAll("(%[0-9A-F]{2}|[^a-zA-Z0-9-_.])+", "_").
+            replaceFirst(".*?(.{0," + maxMnemonic + "}$)", "$1") +
+            uniqueSuffix(name);
         assert result.length() <= PATH_MAX : result + " does not fit inside " + PATH_MAX;
         return result;
+    }
+
+    /**
+     * Cleans up workspace when an orphaned branch project is deleted.
+     * @see "JENKINS-2111"
+     */
+    @Extension
+    public static class Deleter extends ItemListener {
+
+        @Override
+        public void onDeleted(Item item) {
+            if (item.getParent() instanceof MultiBranchProject) {
+                String suffix = uniqueSuffix(item.getFullName());
+                Jenkins jenkins = Jenkins.getActiveInstance();
+                cleanUp(suffix, jenkins.getRootPath().child("workspace"), jenkins);
+                for (Node node : jenkins.getNodes()) {
+                    if (node instanceof Slave) {
+                        cleanUp(suffix, ((Slave) node).getWorkspaceRoot(), node);
+                    }
+                }
+            }
+        }
+
+        private void cleanUp(String suffix, FilePath root, Node node) {
+            try {
+                if (!root.isDirectory()) {
+                    return;
+                }
+                for (FilePath child : root.listDirectories()) {
+                    if (child.getName().endsWith(suffix)) {
+                        LOGGER.log(Level.INFO, "deleting obsolete workspace {0} on {1}", new Object[] {child, node.getNodeName()});
+                        child.deleteRecursive();
+                    }
+                }
+            } catch (IOException | InterruptedException x) {
+                LOGGER.log(Level.WARNING, "could not clean up workspace directories under " + root + " on " + node.getNodeName(), x);
+            }
+        }
+
     }
 
 }

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -113,7 +113,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
 
         private void cleanUp(String suffix, FilePath root, Node node) {
             try {
-                if (!root.isDirectory()) {
+                if (root == null || !root.isDirectory()) {
                     return;
                 }
                 for (FilePath child : root.listDirectories()) {

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -51,15 +51,19 @@ public class WorkspaceLocatorImplTest {
     @WithoutJenkins
     @Test
     public void minimize() {
-        assertEquals("stuff_dev_flow-X0yiR9.BqsTqg9pFIyiV0ATm6dyruRbTOvnNTG9SxW8", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
-        assertEquals("some_longish_name_here_master-ftMhCUghiC48kxZS4Zw6.QohYNA35xl611Xy3HUNe.M", WorkspaceLocatorImpl.minimize("some longish name here/master"));
-        assertEquals("o_much_to_fit_in_a_short_path_at_all-cH_mwM17JKzXFOunEJLQFV6iV4B5V.S2Wi1AC3bM6K0", WorkspaceLocatorImpl.minimize("really way too much to fit in a short path at all"));
-        assertEquals("LIQOQHEADljz_nbflhsfliafdzbclllhdfla-Uj_ZXj._0tE7db2I1CxWsNPBcPjy0saTTJ0QT8iGAxQ", WorkspaceLocatorImpl.minimize("abc!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUHLHULIQOQHEADljz,nbflhsfliafdzbclllhdfla"));
-        assertEquals("llhdflaabcd_hdjlaiuehiuehbn_znxbbLUH-ahHH_tuKAYgION2gQVf2YnyMDSDX306fkceD914r_b0", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcd!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
-        assertEquals("lhdflaabcde_hdjlaiuehiuehbn_znxbbLUH-uPkP5l4k9eSBkVcNaracGXcXUnPfgADiTa7PVyWXa0w", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcde!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
-        assertEquals("hdflaabcdef_hdjlaiuehiuehbn_znxbbLUH-q8tDA_HG4zGluLyc80K9po3VXYHxIETkXoZqI0.lDDE", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcdef!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
-        assertEquals("dflaabcdefg_hdjlaiuehiuehbn_znxbbLUH-F00a2zf8qKtFgFO3WdCsvgWzY9SCgmjjnNJuLfbSans", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcdefg!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
-        assertEquals("a_b_c_d-oy2E86mHig3a7JI3gjl1h1_pFxZuvFiQUZFDQ1B6_jo", WorkspaceLocatorImpl.minimize("a/b/c/d"));
+        assertEquals("a_b-NX345YSMOYT4QUL4OO7V6EGKM57BBNSYVIXGXHCE4KAEVPV5KZYQ", WorkspaceLocatorImpl.minimize("a/b"));
+        assertEquals("a_b_c_d-UMWYJ45JQ6FA3WXMSI3YEOLVQ5P6SFYWN26FRECRSFBUGUD27Y5A", WorkspaceLocatorImpl.minimize("a/b/c/d"));
+        assertEquals("stuff_dev_flow-L5GKER67QGVMJ2UD3JCSGKEV2ACON2O4VO4RNUZ27HGUY32SYVXQ", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
+        assertEquals("me_longish_name_here_master-P3JSCCKIEGEC4PETCZJODHB27EFCCYGQG7TRS6WXKXZNY5INPPRQ", WorkspaceLocatorImpl.minimize("some longish name here/master"));
+        assertEquals("_fit_in_a_short_path_at_all-OB76NQGNPMSKZVYU5OTRBEWQCVPKEV4APFL6JNS2FVAAW5WM5CWQ", WorkspaceLocatorImpl.minimize("really way too much to fit in a short path at all"));
+        assertEquals("abc_esky_-XHOKB7XHQS32PT7KIXIDYFSRSU4SBSGHX3K5O36BMZE2CSLSOVQA", WorkspaceLocatorImpl.minimize("abc!@#$%^&*()[]{}|česky™"));
+        assertEquals("lahblahblahblahblahblahblah-PKYGNQW7EX27MNOU63BZF4FUBUTNK3HIBC37PR673KBZYLRZAQLA", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah"));
+        assertEquals("ahblahblahblahblahblahblahX-B4K3CPB6GP6JRCDBAKDJNRGX42AYU55PGVSOX2UWB5SVLUW42NCA", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahX"));
+        assertEquals("hblahblahblahblahblahblahXY-ZGH2VVOGO2FEM72MZYA7CWRLPBOJK2HZ4YV7IFVDLZPCNVE3CXNQ", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXY"));
+        assertEquals("blahblahblahblahblahblahXYZ-I7NHG3VUEWUH3IFAPUM3HGRL7O4EFAE3FXCXPL35CWOOQSZR6S4Q", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZ"));
+        assertEquals("lahblahblahblahblahblahXYZW-LRVIZHY37BWI3PKRF7WSERGRN3NGPY4T74VWKWNFRMR4IWGXJPQA", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZW"));
+        assertEquals("ahblahblahblahblahblahXYZWV-KLYOGWEJODAVXII3MEM2SLNMRPE7HF6IADTBQ5MP66V3RYCL2LAA", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
+        assertEquals("hblahblahblahblahblahXYZWVU-OSF24EPB4C42KAUXYHPP66XDQHOHKWPHGKZLIWREKOGZDZ46T2PQ", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
     }
 
     @Issue("JENKINS-34564")
@@ -72,9 +76,9 @@ public class WorkspaceLocatorImplTest {
         showComputation(stuff);
         FreeStyleProject master = r.jenkins.getItemByFullName("stuff/dev%2Fflow", FreeStyleProject.class);
         assertNotNull(master);
-        assertEquals(r.jenkins.getRootPath().child("workspace/stuff_dev_flow-X0yiR9.BqsTqg9pFIyiV0ATm6dyruRbTOvnNTG9SxW8"), r.jenkins.getWorkspaceFor(master));
+        assertEquals(r.jenkins.getRootPath().child("workspace/stuff_dev_flow-L5GKER67QGVMJ2UD3JCSGKEV2ACON2O4VO4RNUZ27HGUY32SYVXQ"), r.jenkins.getWorkspaceFor(master));
         DumbSlave slave = r.createOnlineSlave();
-        assertEquals(slave.getWorkspaceRoot().child("stuff_dev_flow-X0yiR9.BqsTqg9pFIyiV0ATm6dyruRbTOvnNTG9SxW8"), slave.getWorkspaceFor(master));
+        assertEquals(slave.getWorkspaceRoot().child("stuff_dev_flow-L5GKER67QGVMJ2UD3JCSGKEV2ACON2O4VO4RNUZ27HGUY32SYVXQ"), slave.getWorkspaceFor(master));
         FreeStyleProject unrelated = r.createFreeStyleProject("100% crazy");
         assertEquals(r.jenkins.getRootPath().child("workspace/100% crazy"), r.jenkins.getWorkspaceFor(unrelated));
     }
@@ -93,12 +97,12 @@ public class WorkspaceLocatorImplTest {
         assertNotNull(master);
         FreeStyleProject pr1 = r.jenkins.getItemByFullName("p/PR-1", FreeStyleProject.class);
         assertNotNull(pr1);
-        assertEquals(r.jenkins.getRootPath().child("workspace/p_master-aUAcX_zHoHqLGnKPdVG8lI8EWxiSbfSTZWe7brOuldg"), r.jenkins.getWorkspaceFor(master));
-        assertEquals(r.jenkins.getRootPath().child("workspace/p_PR-1-4Vkhx2z.S5QnRAYknhYdbgpPuaAIibouodML_pFe914"), r.jenkins.getWorkspaceFor(pr1));
+        assertEquals(r.jenkins.getRootPath().child("workspace/p_master-NFABYX74Y6QHVCY2OKHXKUN4SSHQIWYYSJW7JE3FM65W5M5OSXMA"), r.jenkins.getWorkspaceFor(master));
+        assertEquals(r.jenkins.getRootPath().child("workspace/p_PR-1-4FMSDR3M7ZFZIJ2EAYSJ4FQ5NYFE7ONABCE3ULVB2MF75EK665PA"), r.jenkins.getWorkspaceFor(pr1));
         // Do builds on an agent too.
         DumbSlave slave = r.createOnlineSlave();
-        assertEquals(slave.getWorkspaceRoot().child("p_master-aUAcX_zHoHqLGnKPdVG8lI8EWxiSbfSTZWe7brOuldg"), slave.getWorkspaceFor(master));
-        assertEquals(slave.getWorkspaceRoot().child("p_PR-1-4Vkhx2z.S5QnRAYknhYdbgpPuaAIibouodML_pFe914"), slave.getWorkspaceFor(pr1));
+        assertEquals(slave.getWorkspaceRoot().child("p_master-NFABYX74Y6QHVCY2OKHXKUN4SSHQIWYYSJW7JE3FM65W5M5OSXMA"), slave.getWorkspaceFor(master));
+        assertEquals(slave.getWorkspaceRoot().child("p_PR-1-4FMSDR3M7ZFZIJ2EAYSJ4FQ5NYFE7ONABCE3ULVB2MF75EK665PA"), slave.getWorkspaceFor(pr1));
         master.setAssignedNode(slave);
         assertEquals(2, r.buildAndAssertSuccess(master).getNumber());
         pr1.setAssignedNode(slave);
@@ -113,8 +117,8 @@ public class WorkspaceLocatorImplTest {
         r.waitUntilNoActivity();
         showComputation(p);
         assertEquals(Collections.singletonList(master), r.jenkins.getAllItems(FreeStyleProject.class));
-        assertEquals(Collections.singletonList(r.jenkins.getRootPath().child("workspace/p_master-aUAcX_zHoHqLGnKPdVG8lI8EWxiSbfSTZWe7brOuldg")), r.jenkins.getRootPath().child("workspace").listDirectories());
-        assertEquals(Collections.singletonList(slave.getWorkspaceRoot().child("p_master-aUAcX_zHoHqLGnKPdVG8lI8EWxiSbfSTZWe7brOuldg")), slave.getWorkspaceRoot().listDirectories());
+        assertEquals(Collections.singletonList(r.jenkins.getRootPath().child("workspace/p_master-NFABYX74Y6QHVCY2OKHXKUN4SSHQIWYYSJW7JE3FM65W5M5OSXMA")), r.jenkins.getRootPath().child("workspace").listDirectories());
+        assertEquals(Collections.singletonList(slave.getWorkspaceRoot().child("p_master-NFABYX74Y6QHVCY2OKHXKUN4SSHQIWYYSJW7JE3FM65W5M5OSXMA")), slave.getWorkspaceRoot().listDirectories());
     }
 
 }

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import hudson.model.FreeStyleProject;
+import hudson.scm.NullSCM;
+import hudson.slaves.DumbSlave;
+import static jenkins.branch.NoTriggerBranchPropertyTest.showComputation;
+import jenkins.branch.harness.MultiBranchImpl;
+import jenkins.scm.impl.SingleSCMSource;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+public class WorkspaceLocatorImplTest {
+    
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @WithoutJenkins
+    @Test
+    public void minimize() {
+        assertEquals("stuff_dev_flow-X0yiR9.BqsTqg9pFIyiV0ATm6dyruRbTOvnNTG9SxW8", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
+        assertEquals("some_longish_name_here_master-ftMhCUghiC48kxZS4Zw6.QohYNA35xl611Xy3HUNe.M", WorkspaceLocatorImpl.minimize("some longish name here/master"));
+        assertEquals("o_much_to_fit_in_a_short_path_at_all-cH_mwM17JKzXFOunEJLQFV6iV4B5V.S2Wi1AC3bM6K0", WorkspaceLocatorImpl.minimize("really way too much to fit in a short path at all"));
+        assertEquals("a_b_c_d-oy2E86mHig3a7JI3gjl1h1_pFxZuvFiQUZFDQ1B6_jo", WorkspaceLocatorImpl.minimize("a/b/c/d"));
+    }
+
+    @Issue("JENKINS-34564")
+    @Test
+    public void locate() throws Exception {
+        MultiBranchImpl stuff = r.createProject(MultiBranchImpl.class, "stuff");
+        stuff.getSourcesList().add(new BranchSource(new SingleSCMSource(null, "dev/flow", new NullSCM())));
+        stuff.scheduleBuild2(0).getFuture().get();
+        r.waitUntilNoActivity();
+        showComputation(stuff);
+        FreeStyleProject master = r.jenkins.getItemByFullName("stuff/dev%2Fflow", FreeStyleProject.class);
+        assertNotNull(master);
+        assertEquals(r.jenkins.getRootPath().child("workspace/stuff_dev_flow-X0yiR9.BqsTqg9pFIyiV0ATm6dyruRbTOvnNTG9SxW8"), r.jenkins.getWorkspaceFor(master));
+        DumbSlave slave = r.createOnlineSlave();
+        assertEquals(slave.getWorkspaceRoot().child("stuff_dev_flow-X0yiR9.BqsTqg9pFIyiV0ATm6dyruRbTOvnNTG9SxW8"), slave.getWorkspaceFor(master));
+        FreeStyleProject unrelated = r.createFreeStyleProject("100% crazy");
+        assertEquals(r.jenkins.getRootPath().child("workspace/100% crazy"), r.jenkins.getWorkspaceFor(unrelated));
+    }
+
+}

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -48,6 +48,11 @@ public class WorkspaceLocatorImplTest {
         assertEquals("stuff_dev_flow-X0yiR9.BqsTqg9pFIyiV0ATm6dyruRbTOvnNTG9SxW8", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
         assertEquals("some_longish_name_here_master-ftMhCUghiC48kxZS4Zw6.QohYNA35xl611Xy3HUNe.M", WorkspaceLocatorImpl.minimize("some longish name here/master"));
         assertEquals("o_much_to_fit_in_a_short_path_at_all-cH_mwM17JKzXFOunEJLQFV6iV4B5V.S2Wi1AC3bM6K0", WorkspaceLocatorImpl.minimize("really way too much to fit in a short path at all"));
+        assertEquals("LIQOQHEADljz_nbflhsfliafdzbclllhdfla-Uj_ZXj._0tE7db2I1CxWsNPBcPjy0saTTJ0QT8iGAxQ", WorkspaceLocatorImpl.minimize("abc!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUHLHULIQOQHEADljz,nbflhsfliafdzbclllhdfla"));
+        assertEquals("llhdflaabcd_hdjlaiuehiuehbn_znxbbLUH-ahHH_tuKAYgION2gQVf2YnyMDSDX306fkceD914r_b0", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcd!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
+        assertEquals("lhdflaabcde_hdjlaiuehiuehbn_znxbbLUH-uPkP5l4k9eSBkVcNaracGXcXUnPfgADiTa7PVyWXa0w", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcde!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
+        assertEquals("hdflaabcdef_hdjlaiuehiuehbn_znxbbLUH-q8tDA_HG4zGluLyc80K9po3VXYHxIETkXoZqI0.lDDE", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcdef!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
+        assertEquals("dflaabcdefg_hdjlaiuehiuehbn_znxbbLUH-F00a2zf8qKtFgFO3WdCsvgWzY9SCgmjjnNJuLfbSans", WorkspaceLocatorImpl.minimize("LHULIQOQHEADljz,nbflhsfliafdzbclllhdflaabcdefg!@#$%^&*()[]{}|hdjlaiuehiuehbn,znxbbLUH"));
         assertEquals("a_b_c_d-oy2E86mHig3a7JI3gjl1h1_pFxZuvFiQUZFDQ1B6_jo", WorkspaceLocatorImpl.minimize("a/b/c/d"));
     }
 

--- a/src/test/java/jenkins/branch/harness/BranchProjectFactoryImpl.java
+++ b/src/test/java/jenkins/branch/harness/BranchProjectFactoryImpl.java
@@ -42,7 +42,7 @@ public class BranchProjectFactoryImpl extends BranchProjectFactory<FreeStyleProj
 
     @Override
     public FreeStyleProject newInstance(Branch branch) {
-        FreeStyleProject job = new FreeStyleProject(getOwner(), branch.getName());
+        FreeStyleProject job = new FreeStyleProject(getOwner(), branch.getEncodedName());
         setBranch(job, branch);
         return job;
     }


### PR DESCRIPTION
[JENKINS-34564](https://issues.jenkins-ci.org/browse/JENKINS-34564)

As opposed to #46, this only touches the workspace paths, not the actual `Item.fullName`; guarantees unique names; and bounds path lengths too.

@reviewbybees