### PR TITLE
[JENKINS-39520] ExtensionList.removeAll is unimplemented

### DIFF
--- a/src/main/java/jenkins/branch/CustomOrganizationFolderDescriptor.java
+++ b/src/main/java/jenkins/branch/CustomOrganizationFolderDescriptor.java
@@ -150,7 +150,9 @@ public class CustomOrganizationFolderDescriptor extends TopLevelItemDescriptor i
             }
         }
         LOGGER.log(Level.FINE, "clearing {0}", old);
-        all().removeAll(old);
+        for (CustomOrganizationFolderDescriptor d : old) {
+            all().remove(d);
+        }
         if (ExtensionList.lookup(MultiBranchProjectFactoryDescriptor.class).isEmpty()) {
             LOGGER.fine("no MultiBranchProjectFactoryDescriptor");
             return; // nothing like workflow-multibranch installed, so do not even offer this option

--- a/src/test/java/jenkins/branch/CustomOrganizationFolderDescriptorTest.java
+++ b/src/test/java/jenkins/branch/CustomOrganizationFolderDescriptorTest.java
@@ -32,6 +32,7 @@ import hudson.model.TopLevelItemDescriptor;
 import hudson.model.View;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -110,6 +111,17 @@ public class CustomOrganizationFolderDescriptorTest {
         ExtensionList.lookup(MultiBranchProjectFactoryDescriptor.class).add(new SomeNavigatorSomeFactoryInstalledDescriptor2());
         ExtensionList.lookup(SCMNavigatorDescriptor.class).add(new SomeNavigatorSomeFactoryInstalledDescriptor1());
         assertEquals(Collections.singletonList("MockNavigator"), newItemTypes());
+    }
+
+    @Issue("JENKINS-39520")
+    @SuppressWarnings("deprecation") // ExtensionList.add simulating dynamic installation
+    @Test
+    public void dynamicLoad2() throws Exception {
+        assertEquals(Collections.emptyList(), newItemTypes());
+        ExtensionList.lookup(SCMNavigatorDescriptor.class).add(new SomeNavigatorNoFactoryInstalledDescriptor());
+        ExtensionList.lookup(MultiBranchProjectFactoryDescriptor.class).add(new SomeNavigatorSomeFactoryInstalledDescriptor2());
+        ExtensionList.lookup(SCMNavigatorDescriptor.class).add(new SomeNavigatorSomeFactoryInstalledDescriptor1());
+        assertEquals(Arrays.asList("MockNavigator", "MockNavigator"), newItemTypes());
     }
 
     @Issue("JENKINS-31949")


### PR DESCRIPTION
[JENKINS-39520](https://issues.jenkins-ci.org/browse/JENKINS-39520)

@reviewbybees