### PR TITLE
[JENKINS-34564] Allow workspace paths to be less than 54 characters.

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -56,7 +56,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
 
     /** The most characters to allow in a workspace directory name, relative to the root. Zero to disable altogether. */
     // TODO 2.4+ use SystemProperties
-    private static /* not final */ int PATH_MAX = Integer.getInteger(WorkspaceLocatorImpl.class.getName() + ".PATH_MAX", 80);
+    static /* not final */ int PATH_MAX = Integer.getInteger(WorkspaceLocatorImpl.class.getName() + ".PATH_MAX", 80);
 
     @Override
     public FilePath locate(TopLevelItem item, Node node) {
@@ -75,10 +75,6 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         } else { // ?
             return null;
         }
-    }
-
-    static void setPathMax(int pathMax) {
-        PATH_MAX = pathMax;
     }
 
     static String uniqueSuffix(String name) {
@@ -101,6 +97,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             // and the mnemonic to fit inside PATH_MAX.  The mnemonic always gets
             // at least one character.  The suffix always gets 10 characters plus
             // the "-".  The rest of PATH_MAX is split evenly between the two.
+            LOGGER.log(Level.WARNING, "WorkspaceLocatorImpl.PATH_MAX is small enough that workspace path collisions are more likely to occur");
             final int minSuffix = 10 + /* length("-") */ 1;
             maxMnemonic = Math.max((int)((PATH_MAX - minSuffix) / 2), 1);
             maxSuffix = Math.max(PATH_MAX - maxMnemonic, minSuffix);

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -51,7 +51,7 @@ public class WorkspaceLocatorImplTest {
     @WithoutJenkins
     @Test
     public void minimize() {
-        WorkspaceLocatorImpl.setPathMax(80);
+        WorkspaceLocatorImpl.PATH_MAX = 80;
         assertEquals("a_b-NX345YSMOYT4QUL4OO7V6EGKM57BBNSYVIXGXHCE4KAEVPV5KZYQ", WorkspaceLocatorImpl.minimize("a/b"));
         assertEquals("a_b_c_d-UMWYJ45JQ6FA3WXMSI3YEOLVQ5P6SFYWN26FRECRSFBUGUD27Y5A", WorkspaceLocatorImpl.minimize("a/b/c/d"));
         assertEquals("stuff_dev_flow-L5GKER67QGVMJ2UD3JCSGKEV2ACON2O4VO4RNUZ27HGUY32SYVXQ", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
@@ -66,7 +66,7 @@ public class WorkspaceLocatorImplTest {
         assertEquals("ahblahblahblahblahblahXYZWV-KLYOGWEJODAVXII3MEM2SLNMRPE7HF6IADTBQ5MP66V3RYCL2LAA", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
         assertEquals("hblahblahblahblahblahXYZWVU-OSF24EPB4C42KAUXYHPP66XDQHOHKWPHGKZLIWREKOGZDZ46T2PQ", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
         
-        WorkspaceLocatorImpl.setPathMax(40);
+        WorkspaceLocatorImpl.PATH_MAX = 40;
         assertEquals("a_b-NX345YSMOYT4QUL4OO7V6EGKM", WorkspaceLocatorImpl.minimize("a/b"));
         assertEquals("a_b_c_d-UMWYJ45JQ6FA3WXMSI3YEOLVQ", WorkspaceLocatorImpl.minimize("a/b/c/d"));
         assertEquals("stuff_dev_flow-L5GKER67QGVMJ2UD3JCSGKEV2", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
@@ -81,7 +81,7 @@ public class WorkspaceLocatorImplTest {
         assertEquals("hblahblahXYZWV-KLYOGWEJODAVXII3MEM2SLNMR", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
         assertEquals("blahblahXYZWVU-OSF24EPB4C42KAUXYHPP66XDQ", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
         
-        WorkspaceLocatorImpl.setPathMax(20);
+        WorkspaceLocatorImpl.PATH_MAX = 20;
         assertEquals("a_b-NX345YSMOYT4QUL", WorkspaceLocatorImpl.minimize("a/b"));
         assertEquals("_c_d-UMWYJ45JQ6FA3WX", WorkspaceLocatorImpl.minimize("a/b/c/d"));
         assertEquals("flow-L5GKER67QGVMJ2U", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
@@ -96,7 +96,7 @@ public class WorkspaceLocatorImplTest {
         assertEquals("YZWV-KLYOGWEJODAVXII", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
         assertEquals("ZWVU-OSF24EPB4C42KAU", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
         
-        WorkspaceLocatorImpl.setPathMax(1);
+        WorkspaceLocatorImpl.PATH_MAX = 1;
         assertEquals("b-NX345YSMOY", WorkspaceLocatorImpl.minimize("a/b"));
         assertEquals("d-UMWYJ45JQ6", WorkspaceLocatorImpl.minimize("a/b/c/d"));
         assertEquals("w-L5GKER67QG", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
@@ -112,7 +112,7 @@ public class WorkspaceLocatorImplTest {
         assertEquals("U-OSF24EPB4C", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
         
         // Reset back to 80 for other tests that assume it is 80.
-        WorkspaceLocatorImpl.setPathMax(80);
+        WorkspaceLocatorImpl.PATH_MAX = 80;
     }
 
     @Issue("JENKINS-34564")

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -51,6 +51,7 @@ public class WorkspaceLocatorImplTest {
     @WithoutJenkins
     @Test
     public void minimize() {
+        WorkspaceLocatorImpl.setPathMax(80);
         assertEquals("a_b-NX345YSMOYT4QUL4OO7V6EGKM57BBNSYVIXGXHCE4KAEVPV5KZYQ", WorkspaceLocatorImpl.minimize("a/b"));
         assertEquals("a_b_c_d-UMWYJ45JQ6FA3WXMSI3YEOLVQ5P6SFYWN26FRECRSFBUGUD27Y5A", WorkspaceLocatorImpl.minimize("a/b/c/d"));
         assertEquals("stuff_dev_flow-L5GKER67QGVMJ2UD3JCSGKEV2ACON2O4VO4RNUZ27HGUY32SYVXQ", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
@@ -64,6 +65,54 @@ public class WorkspaceLocatorImplTest {
         assertEquals("lahblahblahblahblahblahXYZW-LRVIZHY37BWI3PKRF7WSERGRN3NGPY4T74VWKWNFRMR4IWGXJPQA", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZW"));
         assertEquals("ahblahblahblahblahblahXYZWV-KLYOGWEJODAVXII3MEM2SLNMRPE7HF6IADTBQ5MP66V3RYCL2LAA", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
         assertEquals("hblahblahblahblahblahXYZWVU-OSF24EPB4C42KAUXYHPP66XDQHOHKWPHGKZLIWREKOGZDZ46T2PQ", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
+        
+        WorkspaceLocatorImpl.setPathMax(40);
+        assertEquals("a_b-NX345YSMOYT4QUL4OO7V6EGKM", WorkspaceLocatorImpl.minimize("a/b"));
+        assertEquals("a_b_c_d-UMWYJ45JQ6FA3WXMSI3YEOLVQ", WorkspaceLocatorImpl.minimize("a/b/c/d"));
+        assertEquals("stuff_dev_flow-L5GKER67QGVMJ2UD3JCSGKEV2", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
+        assertEquals("me_here_master-P3JSCCKIEGEC4PETCZJODHB27", WorkspaceLocatorImpl.minimize("some longish name here/master"));
+        assertEquals("rt_path_at_all-OB76NQGNPMSKZVYU5OTRBEWQC", WorkspaceLocatorImpl.minimize("really way too much to fit in a short path at all"));
+        assertEquals("abc_esky_-XHOKB7XHQS32PT7KIXIDYFSRS", WorkspaceLocatorImpl.minimize("abc!@#$%^&*()[]{}|česky™"));
+        assertEquals("ahblahblahblah-PKYGNQW7EX27MNOU63BZF4FUB", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah"));
+        assertEquals("hblahblahblahX-B4K3CPB6GP6JRCDBAKDJNRGX4", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahX"));
+        assertEquals("blahblahblahXY-ZGH2VVOGO2FEM72MZYA7CWRLP", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXY"));
+        assertEquals("lahblahblahXYZ-I7NHG3VUEWUH3IFAPUM3HGRL7", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZ"));
+        assertEquals("ahblahblahXYZW-LRVIZHY37BWI3PKRF7WSERGRN", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZW"));
+        assertEquals("hblahblahXYZWV-KLYOGWEJODAVXII3MEM2SLNMR", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
+        assertEquals("blahblahXYZWVU-OSF24EPB4C42KAUXYHPP66XDQ", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
+        
+        WorkspaceLocatorImpl.setPathMax(20);
+        assertEquals("a_b-NX345YSMOYT4QUL", WorkspaceLocatorImpl.minimize("a/b"));
+        assertEquals("_c_d-UMWYJ45JQ6FA3WX", WorkspaceLocatorImpl.minimize("a/b/c/d"));
+        assertEquals("flow-L5GKER67QGVMJ2U", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
+        assertEquals("ster-P3JSCCKIEGEC4PE", WorkspaceLocatorImpl.minimize("some longish name here/master"));
+        assertEquals("_all-OB76NQGNPMSKZVY", WorkspaceLocatorImpl.minimize("really way too much to fit in a short path at all"));
+        assertEquals("sky_-XHOKB7XHQS32PT7", WorkspaceLocatorImpl.minimize("abc!@#$%^&*()[]{}|česky™"));
+        assertEquals("blah-PKYGNQW7EX27MNO", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah"));
+        assertEquals("lahX-B4K3CPB6GP6JRCD", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahX"));
+        assertEquals("ahXY-ZGH2VVOGO2FEM72", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXY"));
+        assertEquals("hXYZ-I7NHG3VUEWUH3IF", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZ"));
+        assertEquals("XYZW-LRVIZHY37BWI3PK", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZW"));
+        assertEquals("YZWV-KLYOGWEJODAVXII", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
+        assertEquals("ZWVU-OSF24EPB4C42KAU", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
+        
+        WorkspaceLocatorImpl.setPathMax(1);
+        assertEquals("b-NX345YSMOY", WorkspaceLocatorImpl.minimize("a/b"));
+        assertEquals("d-UMWYJ45JQ6", WorkspaceLocatorImpl.minimize("a/b/c/d"));
+        assertEquals("w-L5GKER67QG", WorkspaceLocatorImpl.minimize("stuff/dev%2Fflow"));
+        assertEquals("r-P3JSCCKIEG", WorkspaceLocatorImpl.minimize("some longish name here/master"));
+        assertEquals("l-OB76NQGNPM", WorkspaceLocatorImpl.minimize("really way too much to fit in a short path at all"));
+        assertEquals("_-XHOKB7XHQS", WorkspaceLocatorImpl.minimize("abc!@#$%^&*()[]{}|česky™"));
+        assertEquals("h-PKYGNQW7EX", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah"));
+        assertEquals("X-B4K3CPB6GP", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahX"));
+        assertEquals("Y-ZGH2VVOGO2", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXY"));
+        assertEquals("Z-I7NHG3VUEW", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZ"));
+        assertEquals("W-LRVIZHY37B", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZW"));
+        assertEquals("V-KLYOGWEJOD", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWV"));
+        assertEquals("U-OSF24EPB4C", WorkspaceLocatorImpl.minimize("blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahXYZWVU"));
+        
+        // Reset back to 80 for other tests that assume it is 80.
+        WorkspaceLocatorImpl.setPathMax(80);
     }
 
     @Issue("JENKINS-34564")


### PR DESCRIPTION
jenkinsci/branch-api-plugin#50 added `PATH_MAX`, which defaults to 80.  I assumed that I could set `PATH_MAX` to 20 to enforce a maximum workspace path of 20 characters.  I need somewhere between 15 and 20 character workspace paths due to Windows path limitations documented in [JENKINS-34564](https://issues.jenkins-ci.org/browse/JENKINS-34564).  However, due to [the way the minimize() function uses `PATH_MAX`](https://github.com/jenkinsci/branch-api-plugin/blob/4fdf888d62848cbf6d91255607d39dd71b536653/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java#L95), the effective minimum for `PATH_MAX` is actually 54 characters, which is too many for me.

This pull request reduces the effective minimum of `PATH_MAX` to 12 characters: one for the last character of the mnemonic, one for the "-", and 10 for the hash.  The unit tests show examples of workspace path names for various `PATH_MAX` values.  I chose 10 characters for the hash by computing the [probability of a collision with 100 workspaces checked out](https://www.wolframalpha.com/input/?i=1+-+e%5E((-100*(100-1))%2F(2*1125899906842624))). 4*(10^-12) seems reasonably low to me.

The default value of `PATH_MAX` is still 80, so this should not affect users who are still using the default value.  This also shouldn't affect users who have `PATH_MAX` set to 54 or higher.  This should only affect users with `PATH_MAX` between 1 and 53, inclusive.

According to @jglick, the original reason the entire 52-character hash was included in the workspace path was to reduce the probability of ["**malicious** collisions, which are easily constructed with weakened hashes"](https://issues.jenkins-ci.org/browse/JENKINS-34564?focusedCommentId=274302&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-274302).  If that is a valid concern then users can keep `PATH_MAX` at 54 or higher.  If that is not a valid concern for some users, or if some users are forced to use shorter paths due to more important concerns and they understand the security risk, then they can reduce `PATH_MAX` below 54.

My understanding is that a ["proper" solution to this problem is being implemented for JENKINS-2111](https://issues.jenkins-ci.org/browse/JENKINS-34564?focusedCommentId=274302&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-274302).  From @jglick:

>The real fix is to maintain a per-node database of workspaces, as discussed in JENKINS-2111. Then each workspace can be given a guaranteed unique, human-readable name of guaranteed maximum length—as well as solving other longstanding issues not limited to branch projects.

However, I don't know when that work will be finished.  That is why I am creating this pull request that does the minimum number of changes to fix my problem instead of waiting an indeterminate amount of time for JENKINS-2111 to be fixed.