### PR TITLE
[JENKINS-40827] Fix the escaping in description column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <scm-api.version>2.0.1-beta-1</scm-api.version>
+    <scm-api.version>2.0.1-20170105.113635-7</scm-api.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
- We do not need to worry about displayName as that is already on code paths that correctly escape

See [JENKINS-40827](https://issues.jenkins-ci.org/browse/JENKINS-40827)

Downstream of https://github.com/jenkinsci/scm-api-plugin/pull/21

@reviewbybees 