### PR TITLE
[JENKINS-40876] Fixes to display of object metadata

### DIFF
--- a/src/main/java/jenkins/branch/ItemColumn.java
+++ b/src/main/java/jenkins/branch/ItemColumn.java
@@ -25,8 +25,6 @@
 package jenkins.branch;
 
 import hudson.Extension;
-import hudson.Util;
-import hudson.markup.MarkupFormatter;
 import hudson.model.Actionable;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
@@ -35,6 +33,7 @@ import hudson.views.ListViewColumn;
 import hudson.views.ListViewColumnDescriptor;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -65,17 +64,26 @@ public class ItemColumn extends ListViewColumn {
     }
 
     /**
-     * Gets the description of a job.
+     * Gets the tool-tip title of a job.
      *
      * @param job the job.
-     * @return the description.
+     * @return the tool-tip title unescaped for use in an attribute.
      */
     @SuppressWarnings("unused") // used via Jelly EL binding
-    public String getDescription(Object job) {
+    public String getTitle(Object job) {
+        // Jelly will take care of quote and ampersand escaping for us
         if (job instanceof Actionable) {
-            ObjectMetadataAction action = ((Actionable)job).getAction(ObjectMetadataAction.class);
-            String description = action != null ? action.getObjectDescription() : null;
-            return description != null ? Util.escape(description) : null;
+            Actionable actionable = (Actionable) job;
+            ObjectMetadataAction action = actionable.getAction(ObjectMetadataAction.class);
+            if (action != null) {
+                String dispayName = action.getObjectDisplayName();
+                if (StringUtils.isBlank(dispayName) || dispayName.equals(actionable.getDisplayName())) {
+                    // if the display name is the same, then the description is more useful
+                    String description = action.getObjectDescription();
+                    return description != null ? description : dispayName;
+                }
+                return dispayName;
+            }
         }
         return null;
     }

--- a/src/main/resources/jenkins/branch/ItemColumn/column.jelly
+++ b/src/main/resources/jenkins/branch/ItemColumn/column.jelly
@@ -29,13 +29,13 @@ THE SOFTWARE.
     <j:choose>
       <j:when test="${it.isPrimary(job)}">
         <strong>
-          <a href="${jobBaseUrl}${job.shortUrl}" class='model-link inside' title="${it.getDescription(job)}">
+          <a href="${jobBaseUrl}${job.shortUrl}" class='model-link inside' title="${it.getTitle(job)}">
             <l:breakable value="${h.getRelativeDisplayNameFrom(job, itemGroup)}"/>
           </a>
         </strong>
       </j:when>
       <j:otherwise>
-        <a href="${jobBaseUrl}${job.shortUrl}" class='model-link inside' title="${it.getDescription(job)}">
+        <a href="${jobBaseUrl}${job.shortUrl}" class='model-link inside' title="${it.getTitle(job)}">
           <l:breakable value="${h.getRelativeDisplayNameFrom(job, itemGroup)}"/>
         </a>
       </j:otherwise>


### PR DESCRIPTION
When [JENKINS-40876](https://issues.jenkins-ci.org/browse/JENKINS-40876) is fixed, it becomes handy to try displaying the ObjectDisplayName and fall back to the Object Description

The following screenshot shows the PR's title being visible as a tool-tip

<img width="1227" alt="screen shot 2017-01-11 at 11 22 26" src="https://cloud.githubusercontent.com/assets/209336/21846945/4dac80a6-d7f1-11e6-8a7f-43c36d3fd3fa.png">

Note: It was really *fun* trying to determine how to handle escaping or not of the value. In the end as this is being directly applied to a HTML attribute, it turns out that Jelly does the required escaping for us. If we were providing this as a HTML value then we might need to escape