### PR TITLE
[JENKINS-41121] This is the best hack fix I can come up with

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -37,6 +37,7 @@ import hudson.BulkChange;
 import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
+import hudson.console.HyperlinkNote;
 import hudson.console.ModelHyperlinkNote;
 import hudson.model.Action;
 import hudson.model.Cause;
@@ -1782,6 +1783,12 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         && revision.isDeterministic()) {
                     // JENKINS-41121 suppress automatic rebuild for branches being re-assoicated with the correct
                     // source id on their first successful scan only.
+                    listener.getLogger().format("%s rediscovered: %s (%s) suspecting %s and suppressing rebuild%n",
+                            StringUtils.defaultIfEmpty(head.getPronoun(), "Branch"),
+                            rawName,
+                            revision,
+                            HyperlinkNote.encodeTo("https://issues.jenkins-ci.org/browse/JENKINS-41121", "JENKINS-41121")
+                            );
                     needSave = true;
                 } else if (rebuild) {
                     listener.getLogger().format(

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -35,6 +35,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
 import hudson.Extension;
+import hudson.PluginManager;
+import hudson.PluginWrapper;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.console.HyperlinkNote;
@@ -59,6 +61,7 @@ import hudson.security.ACL;
 import hudson.security.Permission;
 import hudson.util.LogTaskListener;
 import hudson.util.PersistedList;
+import hudson.util.VersionNumber;
 import hudson.util.io.ReopenableRotatingFileOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -88,6 +91,7 @@ import jenkins.scm.api.SCMEventListener;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
@@ -202,17 +206,45 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         if (state == null) {
             state = new State(this);
         }
-        if (new File(getRootDir(), ".jenkins-41121").isFile()) {
-            legacySourceIds = new HashSet<>(FileUtils.readLines(new File(getRootDir(), ".jenkins-41121")));
-        } else if (state.getStateFile().exists()) {
-            legacySourceIds = null;
-        } else {
-            legacySourceIds = new HashSet<>();
-            for (BranchSource source : sources) {
-                legacySourceIds.add(source.getSource().getId());
+        if (getParent() instanceof OrganizationFolder) {
+            if (new File(getRootDir(), ".jenkins-41121").isFile()) {
+                legacySourceIds = new HashSet<>(FileUtils.readLines(new File(getRootDir(), ".jenkins-41121")));
+            } else {
+                OrganizationFolder orgFolder = (OrganizationFolder) getParent();
+                boolean havePreScm2Navigator = false;
+                PluginManager pluginManager = Jenkins.getActiveInstance().getPluginManager();
+                OUTER: for (SCMNavigator n: orgFolder.getSCMNavigators()) {
+                    PluginWrapper wrapper = pluginManager.whichPlugin(n.getClass());
+                    if (wrapper != null) {
+                        for (PluginWrapper.Dependency d : wrapper.getDependencies()) {
+                            if ("scm-api".equals(d.shortName)) {
+                                if (new VersionNumber(d.version).isOlderThan(new VersionNumber("2.0.0"))) {
+                                    LOGGER.log(Level.WARNING, "Using a SCMNavigator in {0} from the plugin {1}."
+                                                    + "That plugin does not comply with scm-api 2.0.0+ contracts on "
+                                                    + "discovered projects (see JENKINS-41121). Indexing will not "
+                                                    + "trigger builds until after the first full scan with the plugin "
+                                                    + "updated to a version that depends on scm-api 2.0.0 or newer.",
+                                            new Object[]{getParent(), wrapper.getShortName()});
+                                    havePreScm2Navigator = true;
+                                    break OUTER;
+                                }
+                            }
+                        }
+                    }
+                }
+                if (state.getStateFile().exists() && !havePreScm2Navigator) {
+                    legacySourceIds = null;
+                } else {
+                    legacySourceIds = new HashSet<>();
+                    for (BranchSource source : sources) {
+                        legacySourceIds.add(source.getSource().getId());
+                    }
+                    // store the IDs across restarts until we have a full run
+                    FileUtils.writeLines(new File(getRootDir(), ".jenkins-41121"), legacySourceIds);
+                }
             }
-            // store the IDs across restarts until we have a full run
-            FileUtils.writeLines(new File(getRootDir(), ".jenkins-41121"), legacySourceIds);
+        } else {
+            legacySourceIds = null;
         }
         try {
             state.load();
@@ -1781,7 +1813,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         && !(legacySourceIds.contains(source.getId())) // JENKINS-41121 doesn't apply if source retained
                         && legacySourceIds.contains(origBranch.getSourceId())
                         && revision.isDeterministic()) {
-                    // JENKINS-41121 suppress automatic rebuild for branches being re-assoicated with the correct
+                    // JENKINS-41121 stop automatic rebuild for branches being re-assoicated with the correct
                     // source id on their first successful scan only.
                     listener.getLogger().format("%s rediscovered: %s (%s) suspecting %s and suppressing rebuild%n",
                             StringUtils.defaultIfEmpty(head.getPronoun(), "Branch"),

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -38,6 +38,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.PluginManager;
+import hudson.PluginWrapper;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.init.InitMilestone;
@@ -55,6 +57,7 @@ import hudson.model.listeners.SaveableListener;
 import hudson.util.DescribableList;
 import hudson.util.LogTaskListener;
 import hudson.util.PersistedList;
+import hudson.util.VersionNumber;
 import hudson.util.io.ReopenableRotatingFileOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -149,6 +152,10 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
      * @since 2.0
      */
     private transient String facDigest;
+    /**
+     * JENKINS-41121
+     */
+    private transient Boolean legacyScmNavigator;
 
     /**
      * {@inheritDoc}
@@ -253,6 +260,36 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
             return super.getItem(NameMangler.apply(name));
         }
         return item;
+    }
+
+    boolean hasLegacySCMNavigator() {
+        if (legacyScmNavigator == null) {
+            boolean legacyScmNaviagtor = false;
+            PluginManager pluginManager = Jenkins.getActiveInstance().getPluginManager();
+            OUTER:
+            for (SCMNavigator n : getSCMNavigators()) {
+                PluginWrapper wrapper = pluginManager.whichPlugin(n.getClass());
+                if (wrapper != null) {
+                    for (PluginWrapper.Dependency d : wrapper.getDependencies()) {
+                        if ("scm-api".equals(d.shortName)) {
+                            if (new VersionNumber(d.version).isOlderThan(new VersionNumber("2.0.0"))) {
+                                LOGGER.log(Level.WARNING, "Using a SCMNavigator in {0} from the plugin {1}."
+                                                + "That plugin does not comply with scm-api 2.0.0+ contracts on "
+                                                + "discovered projects (see JENKINS-41121). Indexing will not "
+                                                + "trigger builds until after the first full scan with the plugin "
+                                                + "updated to a version that depends on scm-api 2.0.0 or newer.",
+                                        new Object[]{getParent(), wrapper.getShortName()});
+                                legacyScmNaviagtor = true;
+                                break OUTER;
+                            }
+                        }
+                    }
+                }
+            }
+            // idempotent, no need to synchronize
+            legacyScmNavigator = legacyScmNaviagtor;
+        }
+        return legacyScmNavigator;
     }
 
     /**


### PR DESCRIPTION
See the FUD in [JENKINS-41121](https://issues.jenkins-ci.org/browse/JENKINS-41121)

- Will only apply to jobs that are already existing
- Will only apply if the job does not have a `state.xml` (which is introduced in 2.0.0)
- Will keep being applied until a full scan
- Once a full scan has completed, will defang
- Will not affect event triggered builds
- Will not affect non-deterministic revision builds - they trigger polling which should be cheaper

Side effects:

- If there are any changes during the restart of the master, those changes will be ignored *forever*
- We are slowing down job loading by one file existence check

@reviewbybees 