### PR TITLE
[JENKINS-41255] Propagate SCMSource id changes when the new SCMSource is identical to the old

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -392,19 +392,22 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         sources = new ArrayList<>(sources);
         for (ListIterator<BranchSource> i = sources.listIterator(); i.hasNext(); ) {
             BranchSource addition = i.next();
-            if (!additions.contains(addition.getSource().getId())) {
+            String additionId = addition.getSource().getId();
+            if (!additions.contains(additionId)) {
                 continue;
             }
             for (BranchSource removal: this.sources) {
-                if (!removals.contains(removal.getSource().getId())) {
+                String removalId = removal.getSource().getId();
+                if (!removals.contains(removalId)) {
                     continue;
                 }
                 if (!equalButForId(removal.getSource(), addition.getSource())) {
                     continue;
                 }
-                changedIds.put(removal.getSource().getId(), addition.getSource().getId());
-                // now take this one out of consideration
-                removals.remove(removal.getSource().getId());
+                changedIds.put(removalId, additionId);
+                // now take these two out of consideration
+                removals.remove(removalId);
+                additions.remove(additionId);
                 break;
             }
         }

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -1126,9 +1126,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                         if (existing != null) {
                             BulkChange bc = new BulkChange(existing);
                             try {
-                                PersistedList<BranchSource> sourcesList = existing.getSourcesList();
-                                sourcesList.clear();
-                                sourcesList.addAll(createBranchSources());
+                                existing.setSourcesList(createBranchSources());
                                 existing.setOrphanedItemStrategy(getOrphanedItemStrategy());
                                 factory.updateExistingProject(existing, attributes, listener);
                                 ProjectNameProperty property =


### PR DESCRIPTION
See [JENKINS-41255](https://issues.jenkins-ci.org/browse/JENKINS-41255)

@reviewbybees 