### PR TITLE
[JENKINS-41795] Report event origins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <scm-api.version>2.0.2</scm-api.version>
+    <scm-api.version>2.0.3-20170207.105042-1</scm-api.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <scm-api.version>2.0.3-20170207.105042-1</scm-api.version>
+    <scm-api.version>2.0.3</scm-api.version>
   </properties>
 
   <repositories>

--- a/src/main/java/jenkins/branch/BranchEventCause.java
+++ b/src/main/java/jenkins/branch/BranchEventCause.java
@@ -26,6 +26,7 @@
 package jenkins.branch;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Cause;
 import hudson.model.ItemGroup;
 import hudson.model.Run;
@@ -42,6 +43,7 @@ public final class BranchEventCause extends Cause {
     private transient MultiBranchProject<?, ?> multiBranchProject;
 
     private final long timestamp;
+    @NonNull
     private final String origin;
 
     BranchEventCause(SCMEvent<?> event) {
@@ -64,6 +66,7 @@ public final class BranchEventCause extends Cause {
         return new Date(timestamp);
     }
 
+    @NonNull
     public String getOrigin() {
         return origin;
     }

--- a/src/main/java/jenkins/branch/BranchEventCause.java
+++ b/src/main/java/jenkins/branch/BranchEventCause.java
@@ -42,9 +42,11 @@ public final class BranchEventCause extends Cause {
     private transient MultiBranchProject<?, ?> multiBranchProject;
 
     private final long timestamp;
+    private final String origin;
 
     BranchEventCause(SCMEvent<?> event) {
         timestamp = event.getTimestamp();
+        origin = event.getOrigin();
     }
 
     /**
@@ -60,6 +62,10 @@ public final class BranchEventCause extends Cause {
 
     public Date getTimestamp() {
         return new Date(timestamp);
+    }
+
+    public String getOrigin() {
+        return origin;
     }
 
     /**

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -892,9 +892,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
         @Override
         public void onSCMHeadEvent(SCMHeadEvent<?> event) {
             TaskListener global = globalEventsListener();
-            global.getLogger().format("[%tc] Received %s %s event with timestamp %tc%n",
+            global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
                     System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                    event.getTimestamp());
+                    event.getOrigin(), event.getTimestamp());
             int matchCount = 0;
             if (CREATED == event.getType() || UPDATED == event.getType()) {
                 for (OrganizationFolder p : Jenkins.getActiveInstance().getAllItems(OrganizationFolder.class)) {
@@ -934,24 +934,27 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                         }
                         ChildObserver childObserver = p.createEventsChildObserver();
                         long start = System.currentTimeMillis();
-                        listener.getLogger().format("[%tc] Received %s %s event with timestamp %tc%n",
-                                start, event.getClass().getName(), event.getType().name(), event.getTimestamp());
+                        listener.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
+                                start, event.getClass().getName(), event.getType().name(), event.getOrigin(),
+                                event.getTimestamp());
                         try {
                             navigator.visitSources(p.new SCMSourceObserverImpl(listener, childObserver, event), event);
                         } catch (IOException | InterruptedException e) {
                             e.printStackTrace(listener.error(e.getMessage()));
                         } finally {
                             long end = System.currentTimeMillis();
-                            listener.getLogger().format("[%tc] %s %s event processed in %s%n",
+                            listener.getLogger().format(
+                                    "[%tc] %s %s event from %s with timestamp %tc processed in %s%n",
                                     end, event.getClass().getName(), event.getType().name(),
+                                    event.getOrigin(), event.getTimestamp(),
                                     Util.getTimeSpanString(end - start));
                         }
                     }
                 }
             }
-            global.getLogger().format("[%tc] Finished processing %s %s event with timestamp %tc. Matched %d.%n",
+            global.getLogger().format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
                     System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                    event.getTimestamp(), matchCount);
+                    event.getOrigin(), event.getTimestamp(), matchCount);
 
         }
 
@@ -961,9 +964,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
         @Override
         public void onSCMNavigatorEvent(SCMNavigatorEvent<?> event) {
             TaskListener global = globalEventsListener();
-            global.getLogger().format("[%tc] Received %s %s event with timestamp %tc%n",
+            global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
                     System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                    event.getTimestamp());
+                    event.getOrigin(), event.getTimestamp());
             int matchCount = 0;
             if (UPDATED == event.getType()) {
                 Set<SCMNavigator> matches = new HashSet<>();
@@ -1021,9 +1024,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                     }
                 }
             }
-            global.getLogger().format("[%tc] Finished processing %s %s event with timestamp %tc. Matched %d.%n",
+            global.getLogger().format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
                     System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                    event.getTimestamp(), matchCount);
+                    event.getOrigin(), event.getTimestamp(), matchCount);
         }
 
         /**
@@ -1032,9 +1035,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
         @Override
         public void onSCMSourceEvent(SCMSourceEvent<?> event) {
             TaskListener global = globalEventsListener();
-            global.getLogger().format("[%tc] Received %s %s event with timestamp %tc%n",
+            global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
                     System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                    event.getTimestamp());
+                    event.getOrigin(), event.getTimestamp());
             int matchCount = 0;
             if (CREATED == event.getType()) {
                 for (OrganizationFolder p : Jenkins.getActiveInstance().getAllItems(OrganizationFolder.class)) {
@@ -1056,8 +1059,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                         }
                         ChildObserver childObserver = p.createEventsChildObserver();
                         long start = System.currentTimeMillis();
-                        listener.getLogger().format("[%tc] Received %s %s event with timestamp %tc%n",
-                                start, event.getClass().getName(), event.getType().name(), event.getTimestamp());
+                        listener.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
+                                start, event.getClass().getName(), event.getType().name(),
+                                event.getOrigin(), event.getTimestamp());
                         try {
                             for (SCMNavigator n : p.getSCMNavigators()) {
                                 if (event.isMatch(n)) {
@@ -1072,17 +1076,19 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                             e.printStackTrace(listener.error(e.getMessage()));
                         } finally {
                             long end = System.currentTimeMillis();
-                            listener.getLogger().format("[%tc] %s %s event processed in %s%n",
+                            listener.getLogger().format(
+                                    "[%tc] %s %s event from %s with timestamp %tc processed in %s%n",
                                     end, event.getClass().getName(), event.getType().name(),
+                                    event.getOrigin(), event.getTimestamp(),
                                     Util.getTimeSpanString(end - start));
                         }
 
                     }
                 }
             }
-            global.getLogger().format("[%tc] Finished processing %s %s event with timestamp %tc. Matched %d.%n",
+            global.getLogger().format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
                     System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                    event.getTimestamp(), matchCount);
+                    event.getOrigin(), event.getTimestamp(), matchCount);
 
         }
     }

--- a/src/main/resources/jenkins/branch/BranchEventCause/description.jelly
+++ b/src/main/resources/jenkins/branch/BranchEventCause/description.jelly
@@ -28,10 +28,12 @@ THE SOFTWARE.
   <j:set var="url" value="${it.indexingUrl}"/>
   <j:choose>
     <j:when test="${url != null}">
-      <a href="${rootURL}/${url}events">${%blurb(it.timestamp)}</a>
+      <a href="${rootURL}/${url}events" title="${%origin(it.origin)}">${%blurb(it.timestamp)}</a>
     </j:when>
     <j:otherwise>
+      <span title="${%origin(it.origin)}">
       ${%blurb(it.timestamp)}
+      </span>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/src/main/resources/jenkins/branch/BranchEventCause/description.properties
+++ b/src/main/resources/jenkins/branch/BranchEventCause/description.properties
@@ -1,1 +1,2 @@
 blurb=Branch event at {0,time} on {0,date}
+origin=Origin: {0}


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/scm-api-plugin/pull/27

See [JENKINS-41795](https://issues.jenkins-ci.org/browse/JENKINS-41795)

Reports the origin of events, the event logs will now look something like:

![screen shot 2017-02-07 at 11 56 09](https://cloud.githubusercontent.com/assets/209336/22690431/b5baa398-ed2d-11e6-9ffb-0ca21846d4e5.png)

And the tooltip for a branch event will include the origin if known:

![screen shot 2017-02-07 at 11 57 40](https://cloud.githubusercontent.com/assets/209336/22690446/c5c4723c-ed2d-11e6-8152-0e1a344c1926.png)

@reviewbybees 
