### PR TITLE
[JENKINS-41980] SCM triggering should also be suppressed for GitHub webhooks

### DIFF
--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -69,7 +69,7 @@ public class NoTriggerBranchProperty extends BranchProperty {
             for (Action action :  actions) {
                 if (action instanceof CauseAction) {
                     for (Cause c : ((CauseAction) action).getCauses()) {
-                        if (c instanceof BranchIndexingCause) {
+                        if (c instanceof BranchIndexingCause || c instanceof BranchEventCause) {
                             if (p instanceof Job) {
                                 Job<?,?> j = (Job) p;
                                 if (j.getParent() instanceof MultiBranchProject) {

--- a/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
@@ -87,7 +87,7 @@ public class NoTriggerOrganizationFolderProperty extends AbstractFolderProperty<
             for (Action action :  actions) {
                 if (action instanceof CauseAction) {
                     for (Cause c : ((CauseAction) action).getCauses()) {
-                        if (c instanceof BranchIndexingCause) {
+                        if (c instanceof BranchIndexingCause || c instanceof BranchEventCause) {
                             if (p instanceof Job) {
                                 Job<?,?> j = (Job) p;
 


### PR DESCRIPTION
When build is triggered via webhook, the action cause is `BranchEventSource`. Hence the check [here](https://github.com/jenkinsci/branch-api-plugin/blob/master/src/main/java/jenkins/branch/NoTriggerBranchProperty.java#L72) or [here](https://github.com/jenkinsci/branch-api-plugin/blob/master/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java#L90) is bypassed and the answer to `.shouldSchedule` is `true`.