### PR TITLE
[JENKINS-42511] Make sure we do not attempt to create the same branch project twice

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -2043,8 +2043,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 return;
             }
             try (ChildNameGenerator.Trace trace = ChildNameGenerator.beforeCreateItem(
-                    MultiBranchProject.this, branch.getEncodedName(), branch.getName()
+                    MultiBranchProject.this, encodedName, branch.getName()
             )){
+                if (getItem(encodedName) != null) {
+                    throw new IllegalStateException("JENKINS-42511: attempted to redundantly create " + encodedName + " in " + this);
+                }
                 project = _factory.newInstance(branch);
             }
             if (!project.getName().equals(encodedName)) {

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -2046,7 +2046,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     MultiBranchProject.this, encodedName, branch.getName()
             )){
                 if (getItem(encodedName) != null) {
-                    throw new IllegalStateException("JENKINS-42511: attempted to redundantly create " + encodedName + " in " + this);
+                    throw new IllegalStateException("JENKINS-42511: attempted to redundantly create " + encodedName + " in " + MultiBranchProject.this);
                 }
                 project = _factory.newInstance(branch);
             }

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -1314,6 +1314,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                         try (ChildNameGenerator.Trace trace = ChildNameGenerator.beforeCreateItem(
                                 OrganizationFolder.this, folderName, projectName
                         )) {
+                            if (getItem(folderName) != null) {
+                                throw new IllegalStateException("JENKINS-42511: attempted to redundantly create " + folderName + " in " + OrganizationFolder.this);
+                            }
                             project = factory.createNewProject(
                                     OrganizationFolder.this, folderName, sources, attributes, listener
                             );


### PR DESCRIPTION
[JENKINS-42511](https://issues.jenkins-ci.org/browse/JENKINS-42511)

If you run `workflow-aggregator-plugin/demo/` with this patch as a snapshot in `plugins.txt`, and wait for the `cd` folder to index itself on a timer (rather than initiating that manually), you will see that branch indexing runs _twice_, inexplicably with the same timestamp:

```
Mar 07, 2017 12:08:00 AM jenkins.branch.MultiBranchProject$BranchIndexing run
INFO: cd #20170307.000800 branch indexing action completed: SUCCESS in 0.35 sec
Mar 07, 2017 12:08:00 AM jenkins.branch.MultiBranchProject$BranchIndexing run
INFO: cd #20170307.000800 branch indexing action completed: FAILURE in 0.43 sec
```

and this defensive exception gets thrown in the second one. Without it, we silently create a second `WorkflowJob` for the same path, at which point all hell breaks loose.

This PR is not a fix for the underlying problem, but it makes it evident, and seems to prevent any evil symptoms, so that is a start.

@reviewbybees