### PR TITLE
[JENKINS-38837] Add a configuration option for workspaces on master

### DIFF
--- a/src/main/resources/jenkins/branch/Messages.properties
+++ b/src/main/resources/jenkins/branch/Messages.properties
@@ -52,3 +52,7 @@ OrganizationFolder.OrJoinN.First={0}, {1}
 OrganizationFolder.OrJoinN.Middle={0}, {1}
 OrganizationFolder.OrJoinN.Last={0} or {1}
 TaskNounUiTextProvider.TaskNoun=Scan
+JenkinsWorkspaceBaseDirConfiguration.PathDoesNotExist={0} does not exist, it will be created on save and checked for write access.
+JenkinsWorkspaceBaseDirConfiguration.NotWriteable=Can not write to {0}.
+JenkinsWorkspaceBaseDirConfiguration.PathCheckFailed=Failed checking validity of the path: {0}
+JenkinsWorkspaceBaseDirConfiguration.PathIsJenkinsHome=Cannot be JENKINS_HOME, use a sub directory with a relative name.

--- a/src/main/resources/jenkins/branch/WorkspaceLocatorImpl/JenkinsWorkspaceBaseDirConfiguration/config.jelly
+++ b/src/main/resources/jenkins/branch/WorkspaceLocatorImpl/JenkinsWorkspaceBaseDirConfiguration/config.jelly
@@ -1,0 +1,31 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017, CloudBees, Inc..
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:section title="${%Multi Branch Workspace}">
+        <f:entry field="path" title="${%Path}">
+            <f:textbox/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/WorkspaceLocatorImpl/JenkinsWorkspaceBaseDirConfiguration/help-path.html
+++ b/src/main/resources/jenkins/branch/WorkspaceLocatorImpl/JenkinsWorkspaceBaseDirConfiguration/help-path.html
@@ -1,0 +1,7 @@
+<p>
+    The location of multi branch workspaces when running on master. Either a relative path to $JENKINS_HOME or an absolute path to someplace else.
+    A check for write access will be performed when saved.
+</p>
+<p>
+    <strong>NOTE:</strong> When changing this value you will need to manually delete/move any existing workspaces on the old path.
+</p>


### PR DESCRIPTION
[JENKINS-38837](https://issues.jenkins-ci.org/browse/JENKINS-38837)

Because of the fix for [JENKINS-34564](https://issues.jenkins-ci.org/browse/JENKINS-34564) multi branch workspace names don't really fit into how normally workspace paths on the master are calculated.
So instead this introduces the option to configure where to put them as that would solve the original reporters issue with needing to put them on another drive/path than JENKINS_HOME.

@reviewbybees 