### PR TITLE
Remove final from OrganizationFolder declaration

### DIFF
--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -115,7 +115,7 @@ import static jenkins.scm.api.SCMEvent.Type.UPDATED;
  */
 @Restricted(NoExternalUse.class) // not currently intended as an API
 @SuppressWarnings({"unchecked", "rawtypes"}) // mistakes in various places
-public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<?,?>>
+public class OrganizationFolder extends ComputedFolder<MultiBranchProject<?,?>>
         implements SCMNavigatorOwner, IconSpec {
 
     /**


### PR DESCRIPTION
This is so we can make `mock(OrganizationFolder.class)` possible as you cannot reliably mock final classes using Mockito.

We want to write some tests for `io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest` without having to spin up `JenkinsRule` and incur overhead when running these tests.

@reviewbybees 