### PR TITLE
JENKINS-44676 support for env TAG_NAME when head type is tag

### DIFF
--- a/src/main/java/jenkins/branch/BranchNameContributor.java
+++ b/src/main/java/jenkins/branch/BranchNameContributor.java
@@ -33,6 +33,7 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.mixin.TagSCMHead;
 import jenkins.scm.api.actions.ChangeRequestAction;
 import jenkins.scm.api.metadata.ContributorMetadataAction;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
@@ -72,6 +73,9 @@ public class BranchNameContributor extends EnvironmentContributor {
                         envs.putIfNotNull("CHANGE_AUTHOR_DISPLAY_NAME", cma.getContributorDisplayName());
                         envs.putIfNotNull("CHANGE_AUTHOR_EMAIL", cma.getContributorEmail());
                     }
+                }
+                else if(head instanceof TagSCMHead) {
+                	envs.put("TAG_NAME", head.getName());
                 }
             }
         }

--- a/src/main/java/jenkins/branch/BranchNameContributor.java
+++ b/src/main/java/jenkins/branch/BranchNameContributor.java
@@ -75,7 +75,7 @@ public class BranchNameContributor extends EnvironmentContributor {
                     }
                 }
                 else if(head instanceof TagSCMHead) {
-                	envs.put("TAG_NAME", head.getName());
+                    envs.put("TAG_NAME", head.getName());
                 }
             }
         }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-44676

Support for TAG_NAME env variable when head is TagSCMHead.

I'm working on building tags/releases with branch source plugin and this is needed so that pipeline is populated with TAG_NAM env variable.