### PR TITLE
[JENKINS-38837] Handle custom master workspace directory

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -93,7 +93,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
     /** copied from {@link Jenkins} */
     static String expandVariablesForDirectory(String base, String itemFullName, String itemRootDir) {
         return Util.replaceMacro(base, ImmutableMap.of(
-                "JENKINS_HOME", Jenkins.getInstance().getRootDir().getPath(),
+                "JENKINS_HOME", Jenkins.getActiveInstance().getRootDir().getPath(),
                 "ITEM_ROOTDIR", itemRootDir,
                 "ITEM_FULLNAME", itemFullName,   // legacy, deprecated
                 "ITEM_FULL_NAME", itemFullName.replace(':','$'))); // safe, see JENKINS-12251

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -38,6 +38,7 @@ import hudson.model.listeners.ItemListener;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -58,9 +59,10 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
 
     private static final Logger LOGGER = Logger.getLogger(WorkspaceLocatorImpl.class.getName());
 
+    static final int PATH_MAX_DEFAULT = 80;
     /** The most characters to allow in a workspace directory name, relative to the root. Zero to disable altogether. */
     // TODO 2.4+ use SystemProperties
-    static /* not final */ int PATH_MAX = Integer.getInteger(WorkspaceLocatorImpl.class.getName() + ".PATH_MAX", 80);
+    static /* not final */ int PATH_MAX = Integer.getInteger(WorkspaceLocatorImpl.class.getName() + ".PATH_MAX", PATH_MAX_DEFAULT);
 
     @Override
     public FilePath locate(TopLevelItem item, Node node) {
@@ -81,7 +83,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         }
     }
 
-    static String uniqueSuffix(String name) {
+    private static String uniqueSuffix(String name) {
         // TODO still in beta: byte[] sha256 = Hashing.sha256().hashString(name).asBytes();
         byte[] sha256;
         try {
@@ -120,16 +122,18 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
 
         @Override
         public void onDeleted(Item item) {
-            if (item.getParent() instanceof MultiBranchProject) {
-                final String suffix = uniqueSuffix(item.getFullName());
-                Jenkins jenkins = Jenkins.getActiveInstance();
-                Computer.threadPoolForRemoting.submit(new CleanupTask(suffix, jenkins.getRootPath().child("workspace"), "master"));
+            if (!(item instanceof TopLevelItem)) {
+                return;
+            }
+            TopLevelItem tli = (TopLevelItem) item;
+            Jenkins jenkins = Jenkins.getActiveInstance();
+            FilePath masterLoc = new WorkspaceLocatorImpl().locate(tli, jenkins);
+            if (masterLoc != null) {
+                Computer.threadPoolForRemoting.submit(new CleanupTask(masterLoc, "master"));
                 for (Node node : jenkins.getNodes()) {
-                    if (node instanceof Slave) {
-                        FilePath root = ((Slave) node).getWorkspaceRoot();
-                        if (root != null) {
-                            Computer.threadPoolForRemoting.submit(new CleanupTask(suffix, root, node.getNodeName()));
-                        }
+                    FilePath slaveLoc = new WorkspaceLocatorImpl().locate(tli, node);
+                    if (slaveLoc != null) {
+                        Computer.threadPoolForRemoting.submit(new CleanupTask(slaveLoc, node.getNodeName()));
                     }
                 }
             }
@@ -156,41 +160,42 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
 
         private static class CleanupTask implements Runnable {
 
-            /** @see #uniqueSuffix */
             @NonNull
-            private final String suffix;
-
-            @NonNull
-            private final FilePath root;
+            private final FilePath loc;
 
             @NonNull
             private final String nodeName;
 
-            CleanupTask(String suffix, FilePath root, String nodeName) {
-                this.suffix = suffix;
-                this.root = root;
+            CleanupTask(FilePath loc, String nodeName) {
+                this.loc = loc;
                 this.nodeName = nodeName;
                 taskStarted();
             }
 
             @Override
             public void run() {
+                String base = loc.getName();
+                FilePath parent = loc.getParent();
+                if (parent == null) { // unlikely but just in case
+                    return;
+                }
                 Thread t = Thread.currentThread();
                 String oldName = t.getName();
-                t.setName(oldName + ": deleting workspace in " + suffix + " on " + nodeName);
+                t.setName(oldName + ": deleting workspace in " + loc + " on " + nodeName);
                 try {
                     try (Timeout timeout = Timeout.limit(5, TimeUnit.MINUTES)) {
-                        if (!root.isDirectory()) {
+                        List<FilePath> dirs = parent.listDirectories();
+                        if (dirs == null) { // impossible as of https://github.com/jenkinsci/jenkins/pull/2914
                             return;
                         }
-                        for (FilePath child : root.listDirectories()) {
-                            if (child.getName().contains(suffix)) {
+                        for (FilePath child : dirs) {
+                            if (child.getName().startsWith(base)) {
                                 LOGGER.log(Level.INFO, "deleting obsolete workspace {0} on {1}", new Object[] {child, nodeName});
                                 child.deleteRecursive();
                             }
                         }
                     } catch (IOException | InterruptedException x) {
-                        LOGGER.log(Level.WARNING, "could not clean up workspace directories under " + root + " on " + nodeName, x);
+                        LOGGER.log(Level.WARNING, "could not clean up workspace directory " + loc + " on " + nodeName, x);
                     }
                 } finally {
                     t.setName(oldName);


### PR DESCRIPTION
Unlike #98 this adds no UI and does not require users to make any configuration changes. It simply interprets `${ITEM_FULLNAME}` as a sanitized path rather than `Item.fullName`.

Also includes a fix for workspace deletion with custom `PATH_MAX` which I noticed; I really needed to fix that before implementing this anyway.

In the longer term, in JENKINS-2111 I have a proposal for a unified system.

@reviewbybees