### PR TITLE
Display stack traces in logs in a more readable order

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -37,6 +37,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
 import hudson.Extension;
+import hudson.Functions;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.console.ModelHyperlinkNote;
@@ -66,6 +67,7 @@ import hudson.util.XStream2;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -586,7 +588,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 try {
                     sourceActions.put(source.getId(), source.fetchActions(null, listener));
                 } catch (IOException | InterruptedException | RuntimeException e) {
-                    e.printStackTrace(listener.error("[%tc] Could not update folder level actions from source %s",
+                    printStackTrace(e, listener.error("[%tc] Could not update folder level actions from source %s",
                             System.currentTimeMillis(), source.getId()));
                     throw e;
                 }
@@ -607,7 +609,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     try {
                         bc.commit();
                     } catch (IOException | RuntimeException e) {
-                        e.printStackTrace(listener.error("[%tc] Could not persist folder level actions",
+                        printStackTrace(e, listener.error("[%tc] Could not persist folder level actions",
                                 System.currentTimeMillis()));
                         throw e;
                     }
@@ -615,7 +617,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         try {
                             save();
                         } catch (IOException | RuntimeException e) {
-                            e.printStackTrace(listener.error(
+                            printStackTrace(e, listener.error(
                                     "[%tc] Could not persist folder level configuration changes",
                                     System.currentTimeMillis()));
                             throw e;
@@ -630,7 +632,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     source.fetch(new SCMHeadObserverImpl(source, observer, listener, _factory,
                             new IndexingCauseFactory(), null), listener);
                 } catch (IOException | InterruptedException | RuntimeException e) {
-                    e.printStackTrace(listener.error("[%tc] Could not fetch branches from source %s",
+                    printStackTrace(e, listener.error("[%tc] Could not fetch branches from source %s",
                             System.currentTimeMillis(), source.getId()));
                     throw e;
                 }
@@ -652,7 +654,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
             try {
                 factory.setRevisionHash(item, revision);
             } catch (IOException e) {
-                e.printStackTrace(listener.error("Could not update last revision hash"));
+                printStackTrace(e, listener.error("Could not update last revision hash"));
             }
         } else {
             listener.getLogger().println("Did not schedule build for branch: " + name);
@@ -1143,7 +1145,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         );
                     }
                 } catch (InterruptedException e) {
-                    e.printStackTrace(global.error("[%tc] Interrupted while processing %s %s event from %s with timestamp %tc",
+                    printStackTrace(e, global.error("[%tc] Interrupted while processing %s %s event from %s with timestamp %tc",
                             System.currentTimeMillis(), eventDescription, eventType, eventOrigin, eventTimestamp));
                 }
                 global.getLogger()
@@ -1295,9 +1297,9 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 }
                             }
                         } catch (IOException e) {
-                            e.printStackTrace(listener.error(e.getMessage()));
+                            printStackTrace(e, listener.error(e.getMessage()));
                         } catch (InterruptedException e) {
-                            e.printStackTrace(listener.error(e.getMessage()));
+                            printStackTrace(e, listener.error(e.getMessage()));
                             throw e;
                         } finally {
                             long end = System.currentTimeMillis();
@@ -1307,10 +1309,10 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                             Util.getTimeSpanString(end - start));
                         }
                     } catch (IOException e) {
-                        e.printStackTrace(global.error("[%tc] %s encountered an error while processing %s %s event from %s with timestamp %tc",
+                        printStackTrace(e, global.error("[%tc] %s encountered an error while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType, eventOrigin, eventTimestamp));
                     } catch (InterruptedException e) {
-                        e.printStackTrace(global.error("[%tc] %s was interrupted while processing %s %s event from %s with timestamp %tc",
+                        printStackTrace(e, global.error("[%tc] %s was interrupted while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType, eventOrigin, eventTimestamp));
                         throw e;
                     }
@@ -1554,9 +1556,9 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 j.save();
                             }
                         } catch (IOException e) {
-                            e.printStackTrace(listener.error(e.getMessage()));
+                            printStackTrace(e, listener.error(e.getMessage()));
                         } catch (InterruptedException e) {
-                            e.printStackTrace(listener.error(e.getMessage()));
+                            printStackTrace(e, listener.error(e.getMessage()));
                             throw e;
                         } finally {
                             long end = System.currentTimeMillis();
@@ -1566,12 +1568,12 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                             Util.getTimeSpanString(end - start));
                         }
                     } catch (IOException e) {
-                        e.printStackTrace(global.error(
+                        printStackTrace(e, global.error(
                                 "[%tc] %s encountered an error while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
                                 eventOrigin, eventTimestamp));
                     } catch (InterruptedException e) {
-                        e.printStackTrace(global.error(
+                        printStackTrace(e, global.error(
                                 "[%tc] %s was interrupted while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
                                 eventOrigin, eventTimestamp));
@@ -1622,9 +1624,9 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                     }
                                 }
                             } catch (IOException e) {
-                                e.printStackTrace(listener.error(e.getMessage()));
+                                printStackTrace(e, listener.error(e.getMessage()));
                             } catch (InterruptedException e) {
-                                e.printStackTrace(listener.error(e.getMessage()));
+                                printStackTrace(e, listener.error(e.getMessage()));
                                 throw e;
                             } finally {
                                 long end = System.currentTimeMillis();
@@ -1634,13 +1636,13 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                         Util.getTimeSpanString(end - start));
                             }
                         } catch (IOException e) {
-                            e.printStackTrace(global.error(
+                            printStackTrace(e, global.error(
                                     "[%tc] %s encountered an error while processing %s %s event from %s with "
                                             + "timestamp %tc",
                                     System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
                                     eventOrigin, eventTimestamp));
                         } catch (InterruptedException e) {
-                            e.printStackTrace(global.error(
+                            printStackTrace(e, global.error(
                                     "[%tc] %s was interrupted while processing %s %s event from %s with "
                                             + "timestamp %tc",
                                     System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
@@ -1691,7 +1693,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                             try {
                                                 newActions = source.fetchActions(event, listener);
                                             } catch (IOException e) {
-                                                e.printStackTrace(
+                                                printStackTrace(e,
                                                         listener.error("Could not refresh actions for source %s",
                                                                 source.getId()
                                                         ));
@@ -1726,20 +1728,20 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                             }
                                         }
                                     } catch (IOException e) {
-                                        e.printStackTrace(listener.error(e.getMessage()));
+                                        printStackTrace(e, listener.error(e.getMessage()));
                                     } catch (InterruptedException e) {
-                                        e.printStackTrace(listener.error(e.getMessage()));
+                                        printStackTrace(e, listener.error(e.getMessage()));
                                         throw e;
                                     }
                                 } catch (IOException e) {
-                                    e.printStackTrace(global.error(
+                                    printStackTrace(e, global.error(
                                             "[%tc] %s encountered an error while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
                                             eventDescription, event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    e.printStackTrace(global.error(
+                                    printStackTrace(e, global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
@@ -1750,7 +1752,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                             }
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace(global.error(
+                        printStackTrace(e, global.error(
                                 "[%tc] Interrupted while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), eventDescription, event.getType().name(),
                                 event.getOrigin(), event.getTimestamp()));
@@ -1949,13 +1951,13 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     branch.setActions(source.fetchActions(head, event, listener));
                     headActionsFetched = true;
                 } catch (IOException | InterruptedException e) {
-                    e.printStackTrace(listener.error("Could not fetch metadata of branch %s", rawName));
+                    printStackTrace(e, listener.error("Could not fetch metadata of branch %s", rawName));
                 }
                 try {
                     List<Action> actions = source.fetchActions(revision, event, listener);
                     revisionActions = actions.toArray(new Action[actions.size()]);
                 } catch (IOException | InterruptedException e) {
-                    e.printStackTrace(listener.error("Could not fetch metadata for revision %s of branch %s",
+                    printStackTrace(e, listener.error("Could not fetch metadata for revision %s of branch %s",
                             revision, rawName));
                 }
                 if (project != null) {
@@ -2043,7 +2045,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                             project.save();
                         }
                     } catch (IOException e) {
-                        e.printStackTrace(listener.error("Could not save changes to " + rawName));
+                        printStackTrace(e, listener.error("Could not save changes to " + rawName));
                     }
                     return;
                 }
@@ -2249,4 +2251,10 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
             }
         }
     }
+
+    // TODO pending method in Functions in 2.43+
+    static void printStackTrace(@CheckForNull Throwable t, @NonNull PrintWriter pw) {
+        pw.println(Functions.printThrowable(t).trim());
+    }
+
 }

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -351,7 +351,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                 try {
                     actions = navigator.fetchActions(this, null, listener);
                 } catch (IOException e) {
-                    e.printStackTrace(listener.error("[%tc] Could not refresh actions for navigator %s",
+                    MultiBranchProject.printStackTrace(e, listener.error("[%tc] Could not refresh actions for navigator %s",
                             System.currentTimeMillis(), navigator));
                     // preserve previous actions if we have some transient error fetching now (e.g. API rate limit)
                     actions = Util.fixNull(state.getActions().get(navigator));
@@ -373,7 +373,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                     try {
                         bc.commit();
                     } catch (IOException | RuntimeException e) {
-                        e.printStackTrace(listener.error("[%tc] Could not persist folder level actions",
+                        MultiBranchProject.printStackTrace(e, listener.error("[%tc] Could not persist folder level actions",
                                 System.currentTimeMillis()));
                         throw e;
                     }
@@ -381,7 +381,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                         try {
                             save();
                         } catch (IOException | RuntimeException e) {
-                            e.printStackTrace(listener.error(
+                            MultiBranchProject.printStackTrace(e, listener.error(
                                     "[%tc] Could not persist folder level configuration changes",
                                     System.currentTimeMillis()));
                             throw e;
@@ -400,7 +400,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                 try {
                     navigator.visitSources(new SCMSourceObserverImpl(listener, observer, navigator, (SCMSourceEvent<?>) null));
                 } catch (IOException | InterruptedException | RuntimeException e) {
-                    e.printStackTrace(listener.error("[%tc] Could not fetch sources from navigator %s",
+                    MultiBranchProject.printStackTrace(e, listener.error("[%tc] Could not fetch sources from navigator %s",
                             System.currentTimeMillis(), navigator));
                     throw e;
                 }
@@ -973,9 +973,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                                 p.new SCMSourceObserverImpl(listener, childObserver, navigator, event),
                                                 event);
                                     } catch (IOException e) {
-                                        e.printStackTrace(listener.error(e.getMessage()));
+                                        MultiBranchProject.printStackTrace(e, listener.error(e.getMessage()));
                                     } catch (InterruptedException e) {
-                                        e.printStackTrace(listener.error(e.getMessage()));
+                                        MultiBranchProject.printStackTrace(e, listener.error(e.getMessage()));
                                         throw e;
                                     } finally {
                                         long end = System.currentTimeMillis();
@@ -986,14 +986,14 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                                 Util.getTimeSpanString(end - start));
                                     }
                                 } catch (IOException e) {
-                                    e.printStackTrace(global.error(
+                                    MultiBranchProject.printStackTrace(e, global.error(
                                             "[%tc] %s encountered an error while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
                                             globalEventDescription, event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    e.printStackTrace(global.error(
+                                    MultiBranchProject.printStackTrace(e, global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
@@ -1004,7 +1004,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                             }
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace(global.error(
+                        MultiBranchProject.printStackTrace(e, global.error(
                                 "[%tc] Interrupted while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), globalEventDescription, event.getType().name(),
                                 event.getOrigin(), event.getTimestamp()));
@@ -1052,10 +1052,10 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                                 navigatorActions.put(navigator, newActions);
                                             }
                                         } catch (IOException e) {
-                                            e.printStackTrace(
+                                            MultiBranchProject.printStackTrace(e,
                                                     listener.error("Could not fetch metadata from %s", navigator));
                                         } catch (InterruptedException e) {
-                                            e.printStackTrace(listener.error(e.getMessage()));
+                                            MultiBranchProject.printStackTrace(e, listener.error(e.getMessage()));
                                             throw e;
                                         }
                                     }
@@ -1080,13 +1080,13 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                                 p.save();
                                             }
                                         } catch (IOException e) {
-                                            e.printStackTrace(listener.error("Could not persist updated metadata"));
+                                            MultiBranchProject.printStackTrace(e, listener.error("Could not persist updated metadata"));
                                         } finally {
                                             bc.abort();
                                         }
                                     }
                                 } catch (IOException e) {
-                                    e.printStackTrace(global.error(
+                                    MultiBranchProject.printStackTrace(e, global.error(
                                             "[%tc] %s encountered an error while processing %s %s event from %s with "
                                                     + "timestamp %tc",
 
@@ -1094,7 +1094,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                             event.getClass().getName(), event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    e.printStackTrace(global.error(
+                                    MultiBranchProject.printStackTrace(e, global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
@@ -1105,7 +1105,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                             }
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace(global.error(
+                        MultiBranchProject.printStackTrace(e, global.error(
                                 "[%tc] Interrupted while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
                                 event.getOrigin(), event.getTimestamp()));
@@ -1160,12 +1160,12 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                                             event
                                                     );
                                                 } catch (IOException e) {
-                                                    e.printStackTrace(listener.error(e.getMessage()));
+                                                    MultiBranchProject.printStackTrace(e, listener.error(e.getMessage()));
                                                 }
                                             }
                                         }
                                     } catch (InterruptedException e) {
-                                        e.printStackTrace(listener.error(e.getMessage()));
+                                        MultiBranchProject.printStackTrace(e, listener.error(e.getMessage()));
                                         throw e;
                                     } finally {
                                         long end = System.currentTimeMillis();
@@ -1176,7 +1176,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                                 Util.getTimeSpanString(end - start));
                                     }
                                 } catch (IOException e) {
-                                    e.printStackTrace(global.error(
+                                    MultiBranchProject.printStackTrace(e, global.error(
                                             "[%tc] %s encountered an error while processing %s %s event from %s with "
                                                     + "timestamp %tc",
 
@@ -1184,7 +1184,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                             event.getClass().getName(), event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    e.printStackTrace(global.error(
+                                    MultiBranchProject.printStackTrace(e, global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
@@ -1195,7 +1195,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                             }
                         }
                     } catch (InterruptedException e) {
-                        e.printStackTrace(global.error(
+                        MultiBranchProject.printStackTrace(e, global.error(
                                 "[%tc] Interrupted while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
                                 event.getOrigin(), event.getTimestamp()));


### PR DESCRIPTION
Would make the error in [JENKINS-45142](https://issues.jenkins-ci.org/browse/JENKINS-45142) more legible.

@reviewbybees