### PR TITLE
[JENKINS-37491] Splitting OverrideIndexTriggersJobProperty up to support plugins

### DIFF
--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -76,14 +76,13 @@ public class NoTriggerBranchProperty extends BranchProperty {
                                 Job<?,?> j = (Job) p;
                                 if (j.getParent() instanceof MultiBranchProject) {
 
-                                    OverrideIndexTriggersJobProperty overrideProp = j.getProperty(OverrideIndexTriggersJobProperty.class);
-                                    if (overrideProp != null) {
-                                        return overrideProp.getEnableTriggers();
-                                    } else {
-                                        for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
-                                            if (prop instanceof NoTriggerBranchProperty) {
-                                                return false;
-                                            }
+                                    if(OverrideTriggerProperty.isRelevant(j, action)){
+                                        return OverrideTriggerProperty.shouldSchedule(j, action);
+                                    }
+                                    
+                                    for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
+                                        if (prop instanceof NoTriggerBranchProperty) {
+                                            return false;
                                         }
                                     }
                                 }

--- a/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerOrganizationFolderProperty.java
@@ -92,19 +92,19 @@ public class NoTriggerOrganizationFolderProperty extends AbstractFolderProperty<
                                 Job<?,?> j = (Job) p;
 
                                 if (j.getParent() instanceof MultiBranchProject) {
-                                    OverrideIndexTriggersJobProperty overrideProp = j.getProperty(OverrideIndexTriggersJobProperty.class);
-                                    if (overrideProp != null) {
-                                        return overrideProp.getEnableTriggers();
-                                    } else {
-                                        MultiBranchProject mbp = (MultiBranchProject) j.getParent();
-                                        if (mbp.getParent() instanceof OrganizationFolder) {
-                                            NoTriggerOrganizationFolderProperty prop = ((OrganizationFolder) mbp.getParent()).getProperties().get(NoTriggerOrganizationFolderProperty.class);
-                                            if (prop != null) {
-                                                // Not necessarily the same as j.getName(), which may be encoded:
-                                                String name = mbp.getProjectFactory().getBranch(j).getName();
-                                                if (!name.matches(prop.getBranches())) {
-                                                    return false;
-                                                }
+                                    
+                                    if(OverrideTriggerProperty.isRelevant(j, action)){
+                                        return OverrideTriggerProperty.shouldSchedule(j, action);
+                                    }
+
+                                    MultiBranchProject mbp = (MultiBranchProject) j.getParent();
+                                    if (mbp.getParent() instanceof OrganizationFolder) {
+                                        NoTriggerOrganizationFolderProperty prop = ((OrganizationFolder) mbp.getParent()).getProperties().get(NoTriggerOrganizationFolderProperty.class);
+                                        if (prop != null) {
+                                            // Not necessarily the same as j.getName(), which may be encoded:
+                                            String name = mbp.getProjectFactory().getBranch(j).getName();
+                                            if (!name.matches(prop.getBranches())) {
+                                                return false;
                                             }
                                         }
                                     }

--- a/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
+++ b/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java
@@ -43,7 +43,7 @@ import java.util.List;
  * Allows overriding indexing triggers for an individual job - either by enabling when the multibranch or org is set to
  * suppress them, or disabling if they're otherwise enabled.
  */
-public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
+public class OverrideIndexTriggersJobProperty extends OverrideTriggerProperty<Job<?,?>> {
     private final boolean enableTriggers;
 
     @DataBoundConstructor
@@ -53,6 +53,21 @@ public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
 
     public boolean getEnableTriggers() {
         return enableTriggers;
+    }
+
+    public boolean shouldScheduleProperty( Action a ){
+        return this.getEnableTriggers();
+    }
+
+    public boolean isRelevantProperty( Action a ){
+        if (a instanceof CauseAction) {
+            for (Cause c : ((CauseAction) a).getCauses()) {
+                if (c instanceof BranchIndexingCause || c instanceof BranchEventCause) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Extension
@@ -98,8 +113,6 @@ public class OverrideIndexTriggersJobProperty extends JobProperty<Job<?,?>> {
             }
             return true;
         }
-
     }
-
 
 }

--- a/src/main/java/jenkins/branch/OverrideTriggerProperty.java
+++ b/src/main/java/jenkins/branch/OverrideTriggerProperty.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ * Copyright 2017 Spencer Malone
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+import hudson.ExtensionPoint;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import hudson.model.Queue;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+import jenkins.model.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Suppresses builds due to either {@link BranchIndexingCause} or {@link BranchEventCause}.
+ * The purpose of this property is to prevent triggering builds resulting from the <em>detection</em>
+ * of changes in the underlying SCM.
+ */
+public abstract class OverrideTriggerProperty<J extends Job<?,?>> extends JobProperty<Job<?,?>> {
+
+    public abstract boolean shouldScheduleProperty( Action a );
+
+    public abstract boolean isRelevantProperty( Action a );
+
+    public static boolean shouldSchedule(Job<?,?> j, Action a){
+        boolean propertyShouldSchedule = true;
+
+        for (OverrideTriggerProperty potentialProp : OverrideTriggerProperty.all(j)) {
+                propertyShouldSchedule = propertyShouldSchedule && potentialProp.shouldScheduleProperty(a);
+        }
+
+        return propertyShouldSchedule;
+    }
+
+    public static boolean isRelevant(Job<?,?> j, Action a){
+        boolean isRelevantToJob = false;
+
+        for (OverrideTriggerProperty potentialProp : OverrideTriggerProperty.all(j)) {
+                isRelevantToJob = isRelevantToJob || potentialProp.isRelevantProperty(a);
+        }
+
+        return isRelevantToJob;
+    }
+
+    public static ArrayList<OverrideTriggerProperty> all(Job<?,?> j) {
+        ArrayList<OverrideTriggerProperty> list = new ArrayList<OverrideTriggerProperty>();
+        for ( JobProperty param : j.getAllProperties() ){   
+            if(param instanceof OverrideTriggerProperty){
+                list.add((OverrideTriggerProperty) param);
+            }
+        }
+
+        return list;
+    }
+}


### PR DESCRIPTION
Extending OverrideTriggerProperty will now let you stack multiple of these fancy properties together.

@jglick - Thoughts on this approach and then creating plugins as outlined here: https://issues.jenkins-ci.org/browse/JENKINS-37491?focusedCommentId=310597&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-310597

It was my first time fooling around w/ the extension annotation, and I struggled to define an extension that used the descriptor pattern and was a child of another extension (JobProperty). This is what I ended up with instead?

Todo list:

- [x]  Create the OverrideTriggerProperty
- [x]  Implement in the existing triggers for multibranch + pipeline jobs
- [ ]  Implement in subclasses of OverrideTriggerProperty
- [ ]  Unit tests for OverrideTriggerProperty