### PR TITLE
[JENKINS-46957] Use new parent POM to fix PCT issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.25</version>
+    <version>2.33</version>
     <relativePath />
   </parent>
 
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <scm-api.version>2.2.0</scm-api.version>
+    <scm-api.version>2.2.2</scm-api.version>
     <git-plugin.version>3.3.0</git-plugin.version>
   </properties>
 
@@ -115,6 +115,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency> <!-- previously gathered from org.jenkins-ci.lib:lib-jenkins-maven-embedder -->
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
@@ -125,7 +131,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.11</version>
+      <version>2.1.16</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -162,6 +168,12 @@
       <artifactId>subversion</artifactId>
       <version>2.5</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion> <!-- already included by the core -->
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>trilead-ssh2</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[JENKINS-46957](https://issues.jenkins-ci.org/browse/JENKINS-46957)

- Update to 2.33 parent POM.
- Update dependencies accordingly.

@reviewbybees @stephenc 