### PR TITLE
[FIXED JENKINS-48214] Organization folders should handle events for children that are non-buildable

### DIFF
--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -531,10 +531,11 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
      */
     @Override
     public List<SCMSource> getSCMSources() {
-        // Probably unused unless onSCMSourceUpdated implemented, but just in case:
         Set<SCMSource> result = new HashSet<SCMSource>();
         for (MultiBranchProject<?,?> child : getItems()) {
-            result.addAll(child.getSCMSources());
+            if (child.isBuildable()) {
+                result.addAll(child.getSCMSources());
+            }
         }
         return new ArrayList<SCMSource>(result);
     }


### PR DESCRIPTION
See [JENKINS-48214](https://issues.jenkins-ci.org/browse/JENKINS-48214)