### PR TITLE
[JENKINS-48035] Call SCMSource.afterSave when the project is saved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <scm-api.version>2.2.3</scm-api.version>
+    <scm-api.version>2.2.6</scm-api.version>
     <git-plugin.version>3.3.0</git-plugin.version>
   </properties>
 

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -1425,6 +1425,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                 bc.commit();
                             }
                             observer.created(project);
+                            for (SCMSource source : project.getSCMSources()) {
+                                source.afterSave();
+                            }
                             if (isBuildable()) {
                                 project.scheduleBuild(cause());
                             }


### PR DESCRIPTION

See [JENKINS-48035](https://issues.jenkins-ci.org/browse/JENKINS-48035) and [GitHub Branch Source #170](https://github.com/jenkinsci/github-branch-source-plugin/pull/170)


@reviewbybees 