### PR TITLE
[JENKINS-48890] - Do not call BranchProjectFactory.setOwner(null)

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -348,9 +348,6 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         if (factory == projectFactory) {
             return;
         }
-        if (factory != null) {
-            factory.setOwner(null);
-        }
         factory = projectFactory;
         factory.setOwner(this);
     }


### PR DESCRIPTION
Otherwise you sporadically get an [error in `WorkflowMultiBranchProjectFactoryTest.configuredScriptName`](https://ci.jenkins.io/job/Plugins/job/workflow-multibranch-plugin/job/PR-70/2/testReport/org.jenkinsci.plugins.workflow.multibranch/WorkflowMultiBranchProjectFactoryTest/configuredScriptName/):

```
java.lang.IllegalStateException: no parent set on org.jenkinsci.plugins.workflow.job.WorkflowJob[master]
	at hudson.model.AbstractItem.getParent(AbstractItem.java:201)
	at hudson.model.AbstractItem.getRootDir(AbstractItem.java:192)
	at hudson.model.Items.getConfigFile(Items.java:387)
	at hudson.model.AbstractItem.getConfigFile(AbstractItem.java:505)
	at hudson.model.AbstractItem.save(AbstractItem.java:500)
	at hudson.model.Job.save(Job.java:196)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.setDefinition(WorkflowJob.java:180)
	at org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectFactory.setBranch(AbstractWorkflowBranchProjectFactory.java:63)
	at org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectFactory.newInstance(AbstractWorkflowBranchProjectFactory.java:54)
	at org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectFactory.newInstance(AbstractWorkflowBranchProjectFactory.java:44)
	at jenkins.branch.MultiBranchProject$SCMHeadObserverImpl.observe(MultiBranchProject.java:2161)
	at jenkins.scm.api.trait.SCMSourceRequest.process(SCMSourceRequest.java:359)
	at jenkins.plugins.git.AbstractGitSCMSource$8.discoverBranches(AbstractGitSCMSource.java:557)
	at jenkins.plugins.git.AbstractGitSCMSource$8.run(AbstractGitSCMSource.java:535)
	at jenkins.plugins.git.AbstractGitSCMSource$8.run(AbstractGitSCMSource.java:521)
	at jenkins.plugins.git.AbstractGitSCMSource.doRetrieve(AbstractGitSCMSource.java:352)
	at jenkins.plugins.git.AbstractGitSCMSource.retrieve(AbstractGitSCMSource.java:521)
	at jenkins.scm.api.SCMSource._retrieve(SCMSource.java:355)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:265)
	at jenkins.branch.MultiBranchProject.computeChildren(MultiBranchProject.java:634)
	at …
```

Debug logging shows that _sometimes_ the factory is changed while `computeChildren` is running.

```java
final BranchProjectFactory<P, R> _factory = getProjectFactory();
```

calls a `synchronized` method, so at that time it is valid, but later on the factory’s owner is nulled out, and so `AbstractWorkflowBranchProjectFactory.newInstance` passes a null parent to `WorkflowJob.<init>`, and all hell breaks loose.

This might not be the best fix but it seems to work. And I can see no particular reason to have nulled out the `owner` to begin with. Lots of code assumes it is nonnull, and since a stale factory should not be permanently referenced from anywhere, there should be no leak of the `MultiBranchProject`.

@reviewbybees