### PR TITLE
[JENKINS-50777] Export the SCMSource(s) from a MultiBranchProject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <scm-api.version>2.2.6</scm-api.version>
+    <scm-api.version>2.2.7-20180420.001519-1</scm-api.version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/53 -->
     <git-plugin.version>3.3.0</git-plugin.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <scm-api.version>2.2.7-20180420.001519-1</scm-api.version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/53 -->
+    <scm-api.version>2.2.7</scm-api.version>
     <git-plugin.version>3.3.0</git-plugin.version>
   </properties>
 

--- a/src/main/java/jenkins/branch/BranchSource.java
+++ b/src/main/java/jenkins/branch/BranchSource.java
@@ -36,6 +36,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.List;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * A source of branches, which consists of a source and a strategy for creating properties of the branches from this
@@ -43,6 +45,7 @@ import org.kohsuke.stapler.DataBoundSetter;
  *
  * @author Stephen Connolly
  */
+@ExportedBean
 public class BranchSource extends AbstractDescribableImpl<BranchSource> {
     /**
      * The source.
@@ -87,6 +90,7 @@ public class BranchSource extends AbstractDescribableImpl<BranchSource> {
      *
      * @return the source.
      */
+    @Exported
     @NonNull
     public SCMSource getSource() {
         return source;

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -114,6 +114,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * Abstract base class for multiple-branch based projects.
@@ -365,6 +366,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
      *
      * @return the sources of branches.
      */
+    @Exported
     @NonNull
     public List<BranchSource> getSources() {
         if (sources != null) {


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/scm-api-plugin/pull/53, since otherwise you could get a `NotExportableException`.