### PR TITLE
[FIXED JENKINS-50561] Add rateLimitBuilds symbol

### DIFF
--- a/src/main/java/jenkins/branch/RateLimitBranchProperty.java
+++ b/src/main/java/jenkins/branch/RateLimitBranchProperty.java
@@ -45,6 +45,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.jvnet.localizer.ResourceBundleHolder;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -387,7 +388,7 @@ public class RateLimitBranchProperty extends BranchProperty {
         /**
          * Our descriptor.
          */
-        @Extension
+        @Extension @Symbol("rateLimitBuilds")
         @SuppressWarnings("unused") // instantiated by jenkins
         public static class DescriptorImpl extends JobPropertyDescriptor {
 


### PR DESCRIPTION
[JENKINS-50561](https://issues.jenkins-ci.org/browse/JENKINS-50561)

I wanted to avoid "throttle" in the symbol, since that's already a
thing over in Throttle Concurrent Builds, and "throttle" means
something different there than it does here.