### PR TITLE
[JENKINS-45814] Changed suppress property behavior

### DIFF
--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -43,14 +43,28 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 @Restricted(NoExternalUse.class)
 public class NoTriggerBranchProperty extends BranchProperty {
+    private final Boolean disableBranchIndexingCause;
+    private final Boolean disableBranchEventCause;
+
+    public Boolean getDisableBranchIndexingCause() {
+        return disableBranchIndexingCause;
+    }
+
+    public Boolean getDisableBranchEventCause() {
+        return disableBranchEventCause;
+    }
 
     @DataBoundConstructor
-    public NoTriggerBranchProperty() {}
+    public NoTriggerBranchProperty(Boolean disableBranchIndexingCause, Boolean disableBranchEventCause) {
+        this.disableBranchEventCause = disableBranchEventCause;
+        this.disableBranchIndexingCause = disableBranchIndexingCause;
+    }
 
     @Override
     public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
         return null;
     }
+
 
     @Extension
     public static class DescriptorImpl extends BranchPropertyDescriptor {
@@ -82,7 +96,10 @@ public class NoTriggerBranchProperty extends BranchProperty {
                                     } else {
                                         for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
                                             if (prop instanceof NoTriggerBranchProperty) {
-                                                return false;
+                                                if((c instanceof BranchIndexingCause && ((NoTriggerBranchProperty) prop).getDisableBranchIndexingCause()) ||
+                                                        (c instanceof  BranchEventCause && ((NoTriggerBranchProperty) prop).getDisableBranchEventCause())) {
+                                                    return false;
+                                                }
                                             }
                                         }
                                     }

--- a/src/main/resources/jenkins/branch/NoTriggerBranchProperty/config.jelly
+++ b/src/main/resources/jenkins/branch/NoTriggerBranchProperty/config.jelly
@@ -24,4 +24,11 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core"/>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Suppress build after indexing}" field="disableBranchIndexingCause">
+    <f:checkbox default="false"/>
+  </f:entry>
+  <f:entry title="${%Suppress triggered build}" field="disableBranchEventCause">
+    <f:checkbox default="false"/>
+  </f:entry>
+</j:jelly>

--- a/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
@@ -61,7 +61,7 @@ public class NoTriggerBranchPropertyTest {
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
         BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
         branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
-            new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
+            new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty(true, true)})
         }));
         stuff.getSourcesList().add(branchSource);
         r.configRoundtrip(stuff);

--- a/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
+++ b/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
@@ -64,7 +64,7 @@ public class OverrideIndexTriggersJobPropertyTest {
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
         BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
         branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
-            new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
+            new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty(true, true)})
         }));
         stuff.getSourcesList().add(branchSource);
         r.configRoundtrip(stuff);


### PR DESCRIPTION
Hi. I've little bit updated "suppress automatic SCM triggering" property to add more flexible behavior.
I've added ability to choice what kind of event should be suppressed.
![image](https://user-images.githubusercontent.com/6378746/45922027-3a903280-beca-11e8-855d-1c814a260596.png)
For instance, if you have a lot of branch and most of them is triggered after the indexing we lose a lot of resources, and to avoid this would be better to have option to suppress only this type of trigger, but save main functionality and trigger builds by webhooks.
