### PR TITLE
PCT fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>3.28</version>
     <relativePath />
   </parent>
 
@@ -65,7 +65,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.642.3</jenkins.version>
+    <jenkins.version>2.107.3</jenkins.version>
+    <java.level>8</java.level>
     <scm-api.version>2.2.7</scm-api.version>
     <git-plugin.version>3.3.0</git-plugin.version>
   </properties>
@@ -85,16 +86,6 @@
   </pluginRepositories>
 
   <dependencies>
-    <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>access-modifier-annotation</artifactId>
-      <version>1.11</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>annotation-indexer</artifactId>
-      <version>1.9</version>
-    </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/branch/BranchProjectFactory.java
+++ b/src/main/java/jenkins/branch/BranchProjectFactory.java
@@ -204,7 +204,7 @@ public abstract class BranchProjectFactory<P extends Job<P, R> & TopLevelItem,
             List<BranchProperty> properties = new ArrayList<BranchProperty>(branch.getProperties());
             Collections.sort(properties, DescriptorOrder.reverse(BranchProperty.class));
             for (BranchProperty property : properties) {
-                JobDecorator<P, R> decorator = property.jobDecorator(project.getClass());
+                JobDecorator<P, R> decorator = property.jobDecorator((Class) project.getClass());
                 if (decorator != null) {
                     // if Project then we can feed the publishers and build wrappers
                     if (project instanceof Project && decorator instanceof ProjectDecorator) {

--- a/src/main/java/jenkins/branch/RateLimitBranchProperty.java
+++ b/src/main/java/jenkins/branch/RateLimitBranchProperty.java
@@ -41,6 +41,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -75,11 +76,11 @@ public class RateLimitBranchProperty extends BranchProperty {
      */
     private static Map<String, Long> createDurations() {
         Map<String, Long> result = new LinkedHashMap<String, Long>();
-        result.put("hour", TimeUnit2.HOURS.toMillis(1));
-        result.put("day", TimeUnit2.DAYS.toMillis(1));
-        result.put("week", TimeUnit2.DAYS.toMillis(7));
-        result.put("month", TimeUnit2.DAYS.toMillis(31));
-        result.put("year", TimeUnit2.DAYS.toMillis(365));
+        result.put("hour", TimeUnit.HOURS.toMillis(1));
+        result.put("day", TimeUnit.DAYS.toMillis(1));
+        result.put("week", TimeUnit.DAYS.toMillis(7));
+        result.put("month", TimeUnit.DAYS.toMillis(31));
+        result.put("year", TimeUnit.DAYS.toMillis(365));
         return Collections.unmodifiableMap(result);
     }
 
@@ -354,7 +355,7 @@ public class RateLimitBranchProperty extends BranchProperty {
             if (duration < 1) {
                 final String durationName = getDurationName();
                 duration =
-                        DURATIONS.containsKey(durationName) ? DURATIONS.get(durationName) : TimeUnit2.HOURS.toMillis(1);
+                        DURATIONS.containsKey(durationName) ? DURATIONS.get(durationName) : TimeUnit.HOURS.toMillis(1);
             }
             return duration;
         }
@@ -430,36 +431,36 @@ public class RateLimitBranchProperty extends BranchProperty {
              */
             public FormValidation doCheckCount(@QueryParameter int value, @QueryParameter String durationName) {
                 long duration =
-                        DURATIONS.containsKey(durationName) ? DURATIONS.get(durationName) : TimeUnit2.HOURS.toMillis(1);
+                        DURATIONS.containsKey(durationName) ? DURATIONS.get(durationName) : TimeUnit.HOURS.toMillis(1);
                 if (value == 0) {
                     return FormValidation.ok();
                 }
                 long interval = duration / Math.max(1, value);
-                if (interval < TimeUnit2.SECONDS.toMillis(1)) {
+                if (interval < TimeUnit.SECONDS.toMillis(1)) {
                     return FormValidation.ok();
                 }
-                if (interval < TimeUnit2.MINUTES.toMillis(1)) {
+                if (interval < TimeUnit.MINUTES.toMillis(1)) {
                     return FormValidation.ok(
                             Messages.RateLimitBranchProperty_ApproxSecsBetweenBuilds(
-                                    TimeUnit2.MILLISECONDS.toSeconds(interval)));
+                                    TimeUnit.MILLISECONDS.toSeconds(interval)));
                 }
-                if (interval < TimeUnit2.HOURS.toMillis(2)) {
+                if (interval < TimeUnit.HOURS.toMillis(2)) {
                     return FormValidation.ok(
                             Messages.RateLimitBranchProperty_ApproxMinsBetweenBuilds(
-                                    TimeUnit2.MILLISECONDS.toMinutes(interval)));
+                                    TimeUnit.MILLISECONDS.toMinutes(interval)));
                 }
-                if (interval < TimeUnit2.DAYS.toMillis(2)) {
+                if (interval < TimeUnit.DAYS.toMillis(2)) {
                     return FormValidation.ok(
                             Messages.RateLimitBranchProperty_ApproxHoursBetweenBuilds(
-                                    TimeUnit2.MILLISECONDS.toHours(interval)));
+                                    TimeUnit.MILLISECONDS.toHours(interval)));
                 }
-                if (interval < TimeUnit2.DAYS.toMillis(14)) {
+                if (interval < TimeUnit.DAYS.toMillis(14)) {
                     return FormValidation.ok(
                             Messages.RateLimitBranchProperty_ApproxDaysBetweenBuilds(
-                                    TimeUnit2.MILLISECONDS.toDays(interval)));
+                                    TimeUnit.MILLISECONDS.toDays(interval)));
                 }
                 return FormValidation.ok(Messages.RateLimitBranchProperty_ApproxWeeksBetweenBuilds(
-                        TimeUnit2.MILLISECONDS.toDays(interval) / 7));
+                        TimeUnit.MILLISECONDS.toDays(interval) / 7));
             }
         }
     }

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -202,9 +202,6 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                 try {
                     try (Timeout timeout = Timeout.limit(5, TimeUnit.MINUTES)) {
                         List<FilePath> dirs = parent.listDirectories();
-                        if (dirs == null) { // impossible as of https://github.com/jenkinsci/jenkins/pull/2914
-                            return;
-                        }
                         for (FilePath child : dirs) {
                             if (child.getName().startsWith(base)) {
                                 LOGGER.log(Level.INFO, "deleting obsolete workspace {0} on {1}", new Object[] {child, nodeName});

--- a/src/test/java/integration/EventsTest.java
+++ b/src/test/java/integration/EventsTest.java
@@ -81,7 +81,6 @@ import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
 import jenkins.scm.impl.mock.MockSCMDiscoverChangeRequests;
 import jenkins.scm.impl.mock.MockSCMDiscoverTags;
-import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMHeadEvent;
 import jenkins.scm.impl.mock.MockSCMNavigator;
 import jenkins.scm.impl.mock.MockSCMRevision;
@@ -111,6 +110,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
+import org.junit.Ignore;
 
 public class EventsTest {
 
@@ -1637,6 +1637,7 @@ public class EventsTest {
         assertThat("More than one event processed concurrently", maxInflight.get(), greaterThan(1));
     }
 
+    @Ignore("TODO passes locally, but on CI often (and on Windows, always?) fails; seems to be a ClosedByInterruptException")
     @Test
     public void given_multibranch_when_oneEventBlocking_then_otherEventsProcessed() throws Exception {
         List<String> branchNames = Arrays.asList( // top 20 names for boys and girls 2016 in case you are wondering

--- a/src/test/java/jenkins/branch/BuildRetentionBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/BuildRetentionBranchPropertyTest.java
@@ -46,7 +46,7 @@ public class BuildRetentionBranchPropertyTest {
     public void decoratesStandardJobByFieldReflectionAccess() throws Exception {
         BuildRetentionBranchProperty instance = new BuildRetentionBranchProperty(new LogRotator(5, 5, 5, 5));
         Job job = new FreeStyleProject(mock(ItemGroup.class), "foo");
-        assertThat(instance.jobDecorator(Job.class).project(job).getBuildDiscarder(), is(instance.getBuildDiscarder()));
+        assertThat(instance.jobDecorator((Class) Job.class).project(job).getBuildDiscarder(), is(instance.getBuildDiscarder()));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class BuildRetentionBranchPropertyTest {
         BuildRetentionBranchProperty instance = new BuildRetentionBranchProperty(new LogRotator(5, 5, 5, 5));
         Job job = mock(Job.class);
         when(job.getBuildDiscarder()).thenReturn(new LogRotator(0, 0, 0, 0));
-        instance.jobDecorator(Job.class).project(job);
+        instance.jobDecorator((Class) Job.class).project(job);
         verify(job).setBuildDiscarder(instance.getBuildDiscarder());
     }
 
@@ -64,7 +64,7 @@ public class BuildRetentionBranchPropertyTest {
         Job job = mock(Job.class);
         when(job.getBuildDiscarder()).thenReturn(new LogRotator(0, 0, 0, 0));
         doThrow(new IOException("boom")).when(job).setBuildDiscarder(new LogRotator(5, 5, 5, 5));
-        instance.jobDecorator(Job.class).project(job);
+        instance.jobDecorator((Class) Job.class).project(job);
         assertTrue("The IOException was caught and ignored", true);
         verify(job).setBuildDiscarder(instance.getBuildDiscarder());
     }

--- a/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
@@ -89,14 +89,14 @@ public class ParameterDefinitionBranchPropertyTest {
     @Test
     public void isApplicable_Job() throws Exception {
         assertThat("Jobs are not parameterized",
-                new ParameterDefinitionBranchPropertyImpl().isApplicable(Job.class), is(false));
+                new ParameterDefinitionBranchPropertyImpl().isApplicable((Class) Job.class), is(false));
 
     }
 
     @Test
     public void isApplicable_Job_implementing_ParameterizedJob() throws Exception {
         assertThat("Parameterized Jobs are are Applicable",
-                new ParameterDefinitionBranchPropertyImpl().isApplicable(ParamJob.class), is(true));
+                new ParameterDefinitionBranchPropertyImpl().isApplicable((Class) ParamJob.class), is(true));
 
     }
 
@@ -108,12 +108,12 @@ public class ParameterDefinitionBranchPropertyTest {
 
     @Test
     public void jobDecorator_Job() throws Exception {
-        assertThat(new ParameterDefinitionBranchPropertyImpl().jobDecorator(Job.class), nullValue());
+        assertThat(new ParameterDefinitionBranchPropertyImpl().jobDecorator((Class) Job.class), nullValue());
     }
 
     @Test
     public void jobDecorator_Job_implementing_ParameterizedJob() throws Exception {
-        assertThat(new ParameterDefinitionBranchPropertyImpl().jobDecorator(ParamJob.class), notNullValue());
+        assertThat(new ParameterDefinitionBranchPropertyImpl().jobDecorator((Class) ParamJob.class), notNullValue());
     }
 
     @Test

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -124,7 +124,7 @@ public class WorkspaceLocatorImplTest {
     @Issue({"JENKINS-34564", "JENKINS-38837"})
     @Test
     public void locate() throws Exception {
-        assertEquals("${JENKINS_HOME}/workspace/${ITEM_FULLNAME}", r.jenkins.getRawWorkspaceDir());
+        assertEquals("${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}", r.jenkins.getRawWorkspaceDir());
         MultiBranchImpl stuff = r.createProject(MultiBranchImpl.class, "stuff");
         stuff.getSourcesList().add(new BranchSource(new SingleSCMSource(null, "dev/flow", new NullSCM())));
         stuff.scheduleBuild2(0).getFuture().get();


### PR DESCRIPTION
Some backports to the 2.0.20.x line from #129 and #132 which seem to be prerequisites for including this plugin in `plugin-compat-tester` runs, due to a `java.lang.ClassNotFoundException: org.kohsuke.accmod.restrictions.Beta` thrown (but wrapped opaquely as a `java.lang.ArrayStoreException: sun.reflect.annotation.TypeNotPresentExceptionProxy`) during `git` tests.

If merged and released, this would not appear on the UC since it would be older than 2.0.21, so it is only useful for PCT.