### PR TITLE
[JENKINS-54654] WorkspaceLocatorImpl.getWorkspaceRoot did not handle paths using ${ITEM_FULL_NAME} but not ${JENKINS_HOME}

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -256,19 +256,20 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         }
     }
 
-    private static final Pattern GOOD_RAW_WORKSPACE_DIR = Pattern.compile("[$][{]JENKINS_HOME[}]/(.+)/[$][{]ITEM_FULL_?NAME[}]");
-    private static @CheckForNull FilePath getWorkspaceRoot(Node node) {
+    private static final Pattern GOOD_RAW_WORKSPACE_DIR = Pattern.compile("(.+)[/\\\\][$][{]ITEM_FULL_?NAME[}]");
+    static @CheckForNull FilePath getWorkspaceRoot(Node node) {
         if (node instanceof Jenkins) {
             Matcher m = GOOD_RAW_WORKSPACE_DIR.matcher(((Jenkins) node).getRawWorkspaceDir());
             if (m.matches()) {
-                return node.getRootPath().child(m.group(1));
+                return new FilePath(new File(m.group(1).replace("${JENKINS_HOME}", ((Jenkins) node).getRootDir().getAbsolutePath())));
             } else {
-                LOGGER.log(Level.WARNING, "JENKINS-2111 path sanitization ineffective when using legacy Workspace Root Directory ‘{0}’; switch to $'{'JENKINS_HOME'}'/workspace/$'{'ITEM_FULLNAME'}' as in JENKINS-8446 / JENKINS-21942", ((Jenkins) node).getRawWorkspaceDir());
+                LOGGER.log(Level.WARNING, "JENKINS-2111 path sanitization ineffective when using legacy Workspace Root Directory ‘{0}’; switch to ‘$'{'JENKINS_HOME'}'/workspace/$'{'ITEM_FULL_NAME'}'’ as in JENKINS-8446 / JENKINS-21942", ((Jenkins) node).getRawWorkspaceDir());
                 return null;
             }
         } else if (node instanceof Slave) {
             return ((Slave) node).getWorkspaceRoot();
-        } else { // ?
+        } else {
+            LOGGER.log(Level.WARNING, "Unrecognized node {0} of {1}", new Object[] {node, node.getClass()});
             return null;
         }
     }

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -58,6 +59,8 @@ public class WorkspaceLocatorImplTest {
     public JenkinsRule r = new JenkinsRule();
     @Rule
     public LoggerRule logging = new LoggerRule().record(WorkspaceLocatorImpl.class, Level.FINER);
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     @SuppressWarnings("deprecation")
     @Before
@@ -268,6 +271,22 @@ public class WorkspaceLocatorImplTest {
         assertEquals("-project-with-a-rather-long-name", firstWs.getName());
         firstWs.deleteRecursive();
         assertEquals("roject-with-a-rather-long-name_2", r.buildAndAssertSuccess(r.createFreeStyleProject("second-project-with-a-rather-long-name")).getWorkspace().getName());
+    }
+
+    @Issue("JENKINS-54654")
+    @Test
+    public void getWorkspaceRoot() throws Exception {
+        File top = tmp.getRoot();
+        Field workspaceDir = Jenkins.class.getDeclaredField("workspaceDir");
+        workspaceDir.setAccessible(true);
+        workspaceDir.set(r.jenkins, "${ITEM_ROOTDIR}/workspace");
+        assertEquals("old default", null, WorkspaceLocatorImpl.getWorkspaceRoot(r.jenkins));
+        workspaceDir.set(r.jenkins, "${JENKINS_HOME}/workspace/${ITEM_FULL_NAME}");
+        assertEquals("new default", r.jenkins.getRootPath().child("workspace"), WorkspaceLocatorImpl.getWorkspaceRoot(r.jenkins));
+        workspaceDir.set(r.jenkins, "${JENKINS_HOME}/somewhere/else/${ITEM_FULLNAME}");
+        assertEquals("something else using ${JENKINS_HOME} and also deprecated ${ITEM_FULLNAME}", r.jenkins.getRootPath().child("somewhere/else"), WorkspaceLocatorImpl.getWorkspaceRoot(r.jenkins));
+        workspaceDir.set(r.jenkins, top + File.separator + "${ITEM_FULL_NAME}");
+        assertEquals("different location altogether", new FilePath(top), WorkspaceLocatorImpl.getWorkspaceRoot(r.jenkins));
     }
 
 }


### PR DESCRIPTION
[JENKINS-54654](https://issues.jenkins-ci.org/browse/JENKINS-54654)