### PR TITLE
Modifying the 'NoTriggerOrganizationFolderProperty' deprecation message

### DIFF
--- a/src/main/resources/jenkins/branch/Messages.properties
+++ b/src/main/resources/jenkins/branch/Messages.properties
@@ -52,4 +52,4 @@ OrganizationFolder.OrJoinN.First={0}, {1}
 OrganizationFolder.OrJoinN.Middle={0}, {1}
 OrganizationFolder.OrJoinN.Last={0} or {1}
 TaskNounUiTextProvider.TaskNoun=Scan
-NoTriggerOrganizationFolderProperty.PropertyMigration=The "Automatic branch project triggering" option has been replaced with a "Named branch" build strategy
+NoTriggerOrganizationFolderProperty.PropertyMigration=The "Automatic branch project triggering" option has been replaced with a "Named branch" build strategy. Install the "Basic Branch Build Strategies" plugin for this new option.


### PR DESCRIPTION
The **"(Deprecated) Automatic branch project triggering"** option on plugins such as bitbucket/github-branch-source display a confusing deprecation message. The message says that the old option has been replaced with a "Named branch" build strategy, but it's unclear how to access the new option. 

We found that this option is exposed by installing the "Basic Branch Build Strategies" plugin. This PR modifies the message to inform users of the build strategies plugin.