### PR TITLE
[JENKINS-54968] Users may have included a trailing slash in Jenkins.rawWorkspaceDir

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -256,7 +256,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         }
     }
 
-    private static final Pattern GOOD_RAW_WORKSPACE_DIR = Pattern.compile("(.+)[/\\\\][$][{]ITEM_FULL_?NAME[}]");
+    private static final Pattern GOOD_RAW_WORKSPACE_DIR = Pattern.compile("(.+)[/\\\\][$][{]ITEM_FULL_?NAME[}][/\\\\]?");
     static @CheckForNull FilePath getWorkspaceRoot(Node node) {
         if (node instanceof Jenkins) {
             Matcher m = GOOD_RAW_WORKSPACE_DIR.matcher(((Jenkins) node).getRawWorkspaceDir());

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -273,7 +273,7 @@ public class WorkspaceLocatorImplTest {
         assertEquals("roject-with-a-rather-long-name_2", r.buildAndAssertSuccess(r.createFreeStyleProject("second-project-with-a-rather-long-name")).getWorkspace().getName());
     }
 
-    @Issue("JENKINS-54654")
+    @Issue({"JENKINS-54654", "JENKINS-54968"})
     @Test
     public void getWorkspaceRoot() throws Exception {
         File top = tmp.getRoot();
@@ -287,6 +287,8 @@ public class WorkspaceLocatorImplTest {
         assertEquals("something else using ${JENKINS_HOME} and also deprecated ${ITEM_FULLNAME}", r.jenkins.getRootPath().child("somewhere/else"), WorkspaceLocatorImpl.getWorkspaceRoot(r.jenkins));
         workspaceDir.set(r.jenkins, top + File.separator + "${ITEM_FULL_NAME}");
         assertEquals("different location altogether", new FilePath(top), WorkspaceLocatorImpl.getWorkspaceRoot(r.jenkins));
+        workspaceDir.set(r.jenkins, top + File.separator + "${ITEM_FULL_NAME}" + File.separator);
+        assertEquals("different location altogether (with slash)", new FilePath(top), WorkspaceLocatorImpl.getWorkspaceRoot(r.jenkins));
     }
 
 }


### PR DESCRIPTION
[JENKINS-54968](https://issues.jenkins-ci.org/browse/JENKINS-54968)