### PR TITLE
Handle IOException in onOnline when failing to delete workspace, to prevent a node disconnection

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -531,7 +531,12 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                                 String childName = child.getName();
                                 if (childName.equals(path) || childName.startsWith(path + COMBINATOR)) {
                                     listener.getLogger().println("deleting obsolete workspace " + child);
-                                    child.deleteRecursive();
+                                    try {
+                                        child.deleteRecursive();
+                                    } catch (IOException x) {
+                                        LOGGER.log(Level.WARNING, "could not delete workspace " + child, x);
+                                        listener.getLogger().println("could not delete workspace " + child + " , wrong file ownership? Review exception in jenkins log and manually remove the directory");
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Hello,
currently a failed workspace deletion attempt within onOnline will result in node disconnection, because the exception is not handled.

Unfortunately workspace deletion issues are getting more common as users run jobs inside docker containers that might run with a different user than jenkins, thus resulting in files left around in the workspace that jenkins can't delete. While this is a user problem and should be dealt with by ensuring jobs clean up their own files, what would normally be just an annoyance (the workspace files left around) can turn into an outage as the node fails to re-connect if it can't delete a workspace.

So this patch mitigates the issue by preventing onOnline from failing and by warning the operator that there are workspaces requiring manual cleanup (or jobs requiring a review).

Please note that https://issues.jenkins-ci.org/browse/JENKINS-55597 might be related to this or it might be another plugin - in my case it was branch-api not handling the exception so I patched it.

Kind regards