### PR TITLE
Support for programmatically generating OrganizationFolders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -769,7 +769,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     @Override
     public ACL getACL() {
         final ACL acl = super.getACL();
-        if (getParent() instanceof OrganizationFolder) {
+        if (getParent() instanceof ComputedFolder<?>) {
             return new ACL() {
                 @Override
                 public boolean hasPermission(Authentication a, Permission permission) {

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -31,7 +31,6 @@ import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
 import com.cloudbees.hudson.plugins.folder.computed.EventOutputStreams;
 import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
-import com.google.common.collect.ImmutableSet;
 import com.thoughtworks.xstream.XStreamException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -70,6 +69,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -788,7 +788,8 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     }
 
     private static final Set<Permission> SUPPRESSED_PERMISSIONS =
-            ImmutableSet.of(Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE);
+        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE)));
 
     /**
      * {@inheritDoc}

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -24,43 +24,7 @@
 
 package jenkins.branch;
 
-import static jenkins.scm.api.SCMEvent.Type.CREATED;
-import static jenkins.scm.api.SCMEvent.Type.UPDATED;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.servlet.ServletException;
-
-import org.acegisecurity.AccessDeniedException;
-import org.acegisecurity.Authentication;
-import org.apache.commons.io.Charsets;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
-import org.jenkins.ui.icon.Icon;
-import org.jenkins.ui.icon.IconSet;
-import org.jenkins.ui.icon.IconSpec;
-import org.jvnet.localizer.LocaleProvider;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-
+import antlr.ANTLRException;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.ChildNameGenerator;
@@ -74,8 +38,6 @@ import com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import com.google.common.collect.ImmutableSet;
 import com.thoughtworks.xstream.XStreamException;
-
-import antlr.ANTLRException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
 import hudson.Extension;
@@ -100,6 +62,24 @@ import hudson.security.ACL;
 import hudson.security.Permission;
 import hudson.util.DescribableList;
 import hudson.util.StreamTaskListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import jenkins.model.TransientActionFactory;
 import jenkins.scm.api.SCMEvent;
@@ -118,6 +98,22 @@ import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.impl.SingleSCMNavigator;
 import jenkins.scm.impl.UncategorizedSCMSourceCategory;
+import org.acegisecurity.AccessDeniedException;
+import org.acegisecurity.Authentication;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkins.ui.icon.Icon;
+import org.jenkins.ui.icon.IconSet;
+import org.jenkins.ui.icon.IconSpec;
+import org.jvnet.localizer.LocaleProvider;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import static jenkins.scm.api.SCMEvent.Type.CREATED;
+import static jenkins.scm.api.SCMEvent.Type.UPDATED;
 
 /**
  * A folder-like collection of {@link MultiBranchProject}s, one per repository.

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -186,12 +186,16 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
     @Override
     public void onCreatedFromScratch() {
         super.onCreatedFromScratch();
-        for (MultiBranchProjectFactoryDescriptor d : ExtensionList.lookup(MultiBranchProjectFactoryDescriptor.class)) {
-            MultiBranchProjectFactory f = d.newInstance();
-            if (f != null) {
-                projectFactories.add(f);
+
+        if( projectFactories.isEmpty() ) {
+            for (MultiBranchProjectFactoryDescriptor d : ExtensionList.lookup(MultiBranchProjectFactoryDescriptor.class)) {
+                MultiBranchProjectFactory f = d.newInstance();
+                if (f != null) {
+                    projectFactories.add(f);
+                }
             }
         }
+
         try {
             addTrigger(new PeriodicFolderTrigger("1d"));
         } catch (ANTLRException x) {

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -36,7 +36,6 @@ import com.cloudbees.hudson.plugins.folder.computed.EventOutputStreams;
 import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
 import com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
-import com.google.common.collect.ImmutableSet;
 import com.thoughtworks.xstream.XStreamException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.BulkChange;
@@ -65,6 +64,7 @@ import hudson.util.StreamTaskListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -682,7 +682,8 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
     }
 
     private static final Set<Permission> SUPPRESSED_PERMISSIONS =
-                ImmutableSet.of(Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE);
+        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE)));
 
     /**
      * Our descriptor

--- a/src/test/java/jenkins/branch/OrganizationFolderTest.java
+++ b/src/test/java/jenkins/branch/OrganizationFolderTest.java
@@ -24,30 +24,9 @@
 
 package jenkins.branch;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.acegisecurity.Authentication;
-import org.acegisecurity.providers.TestingAuthenticationToken;
-import org.junit.Rule;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.TestExtension;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import com.cloudbees.hudson.plugins.folder.computed.ChildObserver;
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
 import com.google.common.collect.ImmutableSet;
-
 import hudson.ExtensionList;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
@@ -56,6 +35,11 @@ import hudson.model.TaskListener;
 import hudson.model.View;
 import hudson.scm.NullSCM;
 import hudson.security.Permission;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import jenkins.branch.harness.MultiBranchImpl;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMSource;
@@ -68,6 +52,19 @@ import jenkins.scm.impl.mock.MockSCMDiscoverChangeRequests;
 import jenkins.scm.impl.mock.MockSCMDiscoverTags;
 import jenkins.scm.impl.mock.MockSCMHead;
 import jenkins.scm.impl.mock.MockSCMNavigator;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.providers.TestingAuthenticationToken;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
 
 public class OrganizationFolderTest {
 

--- a/src/test/java/jenkins/branch/OrganizationFolderTest.java
+++ b/src/test/java/jenkins/branch/OrganizationFolderTest.java
@@ -270,11 +270,16 @@ public class OrganizationFolderTest {
                     throws IOException, InterruptedException
             {
                 /*
-                 * doesn't look like we can actually compute children during a unit test.
-                 * Normally we'd want to create the OrganizationFolder here
-                 * to match the "real" Jenkins workflow as closely as possible
+                 * We don't actually need to compute children during a unit test.
+                 * We just need an OrganizationFolder to have this ComputedFolder
+                 * as its parent.
+                 *
+                 * Since item parents are set on the item when constructing it,
+                 * we can do that when we create the OrganizationFolder.
+                 *
+                 * Also, #scheduleBuild(...) to enqueue a computeChildren
+                 * doesn't work out-of-the-box in the current unit-test setup.
                  */
-
             }
         };
 

--- a/src/test/java/jenkins/branch/OrganizationFolderTest.java
+++ b/src/test/java/jenkins/branch/OrganizationFolderTest.java
@@ -26,7 +26,6 @@ package jenkins.branch;
 
 import com.cloudbees.hudson.plugins.folder.computed.ChildObserver;
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
-import com.google.common.collect.ImmutableSet;
 import hudson.ExtensionList;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
@@ -36,7 +35,9 @@ import hudson.model.View;
 import hudson.scm.NullSCM;
 import hudson.security.Permission;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -255,7 +256,8 @@ public class OrganizationFolderTest {
     public void modifyAclsWhenInComputedFolder() throws IOException, InterruptedException {
 
         Set<Permission> suppressed_permissions =
-            ImmutableSet.of(Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE);
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE)));
 
         // we need a ComputedFolder to be the parent of our OrganizationFolder
         ComputedFolder<OrganizationFolder> computed_folder = new ComputedFolder<OrganizationFolder>(r.jenkins, "top") {
@@ -299,7 +301,8 @@ public class OrganizationFolderTest {
     public void modifyAclsWhenNotInComputedFolder() throws IOException {
 
         Set<Permission> suppressed_permissions =
-            ImmutableSet.of(Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE);
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                Item.CONFIGURE, Item.DELETE, View.CONFIGURE, View.CREATE, View.DELETE)));
 
         OrganizationFolder top = r.jenkins.createProject(OrganizationFolder.class, "top");
 


### PR DESCRIPTION
In my own life, I am building a Jenkins plugin that adds the ability to generate `OrganizationFolder`s for a user against an SCM server (each of which will then generate `MultiBranchProjects` for each repo, as an `OrganizationFolder` does).

Suppress modify permissions in OrganizationFolder when it is a direct child of a ComputedFolder
=====

The [`MultiBranchProject` detects if it is a child of an `OrganizationFolder`](https://github.com/jenkinsci/branch-api-plugin/blob/master/src/main/java/jenkins/branch/MultiBranchProject.java#L776-L797) and hides from users the ability to directly update and delete it, because it is managed programmatically by the `ComputedFolder` aspect of `OrganizationFolder`.

`OrganizationFolder` itself does _not_ do this, so the automatically-generated organization folders can be modified and deleted by users after their creation. This isn't ideal.

I have taken the (above-linked) code block from `MultiBranchProject` that hides the modification permissions when it should, and added it to `OrganizationFolder`

I have made one change: Instead of checking for a _specific implementation_ parent class, it will hide those permissions any time it is a child of a `ComputedFolder` - so anyone that computes & generates `OrganizationFolder`s will get the correct behavior regardless of their specific implementation class' type.

I would have preferred to keep this entirely in my own plugin code by extending `OrganizationFolder` but it is a `final` class and so I must make the code change here. 

**I believe this is a low-risk contribution with value to all plugin authors, not just myself**.

I don't know of anyone (or any plugin) that currently puts `OrganizationFolder`s in `ComputedFolder`s _and_ expects human users to be able to modify & delete them through the WebUI. If any such users _do_ exist, though, this change would break their workflow.

Do not use default MultiBranchProjectFactory(ies) onCreatedFromScratch if some exist
=====

Currently, when an OrganizationFolder is created the `onCreatedFromScratch()` method will add all enabled-by-default MultiBranchProjectFactory types to the OrganizationFolder.

This updates that behavior to skip adding the factories if and only if there were already some factories set. This allows code that creates an OrganizationFolder to also specify which project factories the folder should use, and ensures that the OrganizationFolder won't go and add additional factories on its own.

**I believe this is a low-risk contribution.**

Only other workflows that were programmatically creating OrganizationFolders _and_ relying on the default MultiBranchProjectFactory classes being added to the folders _in addition to at least one non-default factory that the workflow added_ would experience a change in behavior.