### PR TITLE
Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.24</version>
+    <version>3.42</version>
     <relativePath />
   </parent>
 

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -1570,6 +1570,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     try (StreamTaskListener listener = p.getComputation().createEventsListener();
                          ChildObserver childObserver = p.openEventsChildObserver()) {
                         try {
+                            assert childObserver != null;
                             listener.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
                                     start, eventDescription, eventType, eventOrigin, eventTimestamp);
                             for (Map.Entry<SCMSource, SCMHead> m : matches.entrySet()) {

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -211,12 +211,12 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             return null;
         }
     }
-    
+
     private static Map<String, String> load(FilePath workspace) throws IOException, InterruptedException {
         Map<String, String> map = new TreeMap<>();
         FilePath index = workspace.child(INDEX_FILE_NAME);
         if (index.exists()) {
-            try (InputStream is = index.read(); Reader r = new InputStreamReader(is, StandardCharsets.UTF_8); BufferedReader br = new BufferedReader(r)) {
+            try (InputStream is = readFilePath(index);  Reader r = new InputStreamReader(is, StandardCharsets.UTF_8); BufferedReader br = new BufferedReader(r)) {
                 while (true) {
                     String key = br.readLine();
                     if (key == null) {
@@ -231,6 +231,15 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             }
         }
         return map;
+    }
+
+    // Workaround spotbugs false-positive redunant null checking for try blocks in java 11
+    // https://github.com/spotbugs/spotbugs/issues/756
+    @NonNull
+    private static InputStream readFilePath(@NonNull FilePath index) throws IOException, InterruptedException {
+        InputStream stream = index.read();
+        assert stream != null;
+        return stream;
     }
 
     private static void save(Map<String, String> index, FilePath workspace) throws IOException, InterruptedException {


### PR DESCRIPTION
Making sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))

@jenkinsci/java11-support 