### PR TITLE
[JENKINS-38552] Use a lastSeenRevision + lastBuilt

### DIFF
--- a/docs/implementation.adoc
+++ b/docs/implementation.adoc
@@ -672,3 +672,23 @@ The anticipated specializations are around the `SCMSource` types, but the API co
 This should be relatively similar to regular Jenkins extensions.
 For example, you should check that the configuration round trips via the UI, that the functionality gets applied in the correct circumstances, etc.
 
+==== Implementing `jenkins.branch.BranchBuildStrategy`
+
+// TODO This is just simple doc to document the different between lastBuiltRevision and lastSeenRevision, but it needs to be improved
+
+The `BranchBuildStrategy` is an extension point that allows controlling whether a specific `SCMHead` should be automatically built when it is discovered.
+
+It incorporates an API to expose the external code and a SPI (Service Provider Interface).
+
+ * SPI methods are intended to be implemented by implementers of `BranchBuildStrategy`.
+ * API methonds are intended to be invoked consumers of `BranchBuildStrategy`.
+ * SPI methonds are only to be invoked through the API methods in order to allow safe evolution.
+ * Changing the API may require updating any SPI implementations that are also API consumers, specifically the Any, All and None implementations in basic-branch-build-strategies-plugin
+
+
+The API and SPI provides you:
+
+* `currRevision` which provides the `SCMRevision` that the head is now at
+* `lastBuiltRevision` which provides the `SCMRevision` that the build head was last seen
+* `lastSeenRevision` which provides the `SCMRevision` that the head was last seen
+

--- a/src/main/java/jenkins/branch/BranchBuildStrategy.java
+++ b/src/main/java/jenkins/branch/BranchBuildStrategy.java
@@ -217,8 +217,6 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
         return automaticBuild(source, head, currRevision, prevRevision, listener, null);
     }
 
-
-
     /**
      * API: Should the specified {@link SCMRevision} of the {@link SCMHead} for the specified {@link SCMSource} be
      * triggered when the {@link SCMHead} has been detected as created / modified?

--- a/src/main/java/jenkins/branch/BranchBuildStrategy.java
+++ b/src/main/java/jenkins/branch/BranchBuildStrategy.java
@@ -155,7 +155,7 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
      *                     {@link SCMRevision#isDeterministic()} previous revisions as polling for changes will have
      *                     confirmed that there is a change between this and {@code currRevision} even if the two
      *                     are equal.
-     * @param lastSeenRevision the {@link SCMRevision} that the head is now at
+     * @param lastSeenRevision the {@link SCMRevision} that the head was last seen
      * @param listener     the {@link TaskListener} that can be used for outputting any rational for the decision
      * @return {@code true} if and only if the {@link SCMRevision} should be automatically built when the
      * {@link SCMHead} has been detected as created / modified.
@@ -231,7 +231,7 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
      *                     {@link SCMRevision#isDeterministic()} previous revisions as polling for changes will have
      *                     confirmed that there is a change between this and {@code currRevision} even if the two
      *                     are equal.
-     * @param lastSeenRevision the {@link SCMRevision} that the head is now at
+     * @param lastSeenRevision the {@link SCMRevision} that the head was last seen
      * @return {@code true} if and only if the {@link SCMRevision} should be automatically built when the
      * {@link SCMHead} has been detected as created / modified.
      * @since 2.4.2

--- a/src/main/java/jenkins/branch/BranchBuildStrategy.java
+++ b/src/main/java/jenkins/branch/BranchBuildStrategy.java
@@ -35,7 +35,6 @@ import java.util.logging.Logger;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
-import jline.internal.Nullable;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
 
@@ -46,6 +45,9 @@ import org.kohsuke.accmod.restrictions.ProtectedExternally;
  * Methods marked as {@code SPI:} are intended to be implemented by implementers of {@link BranchBuildStrategy}.
  * Methods marked as {@code API:} are intended to be invoked consumers of {@link BranchBuildStrategy}.
  * A consumer invoking a {@code SPI:} method may get a {@link UnsupportedOperationException}.
+ * Methods marked as {@code SPI:} are only to be invoked through the API methods in order to allow safe evolution.
+ * Changing the API may require updating any SPI implementations that are also API consumers, specifically the Any,
+ * All and None implementations in basic-branch-build-strategies
  *
  * @since 2.0.0
  */
@@ -224,7 +226,7 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
      * @param source       the {@link SCMSource}
      * @param head         the {@link SCMHead}
      * @param currRevision the {@link SCMRevision} that the head is now at
-     * @param lastBuiltRevision the {@link SCMRevision} that the head was last seen at or {@code null} if this is a newly
+     * @param lastBuiltRevision the {@link SCMRevision} that the build head was last seen at or {@code null} if this is a newly
      *                     discovered head. Care should be taken to consider the case of non
      *                     {@link SCMRevision#isDeterministic()} previous revisions as polling for changes will have
      *                     confirmed that there is a change between this and {@code currRevision} even if the two
@@ -232,7 +234,7 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
      * @param lastSeenRevision the {@link SCMRevision} that the head is now at
      * @return {@code true} if and only if the {@link SCMRevision} should be automatically built when the
      * {@link SCMHead} has been detected as created / modified.
-     * @since 2.1.3
+     * @since 2.4.2
      */
     @SuppressWarnings("deprecation")
     public final boolean automaticBuild(@NonNull SCMSource source,
@@ -243,7 +245,7 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
                                         @NonNull TaskListener listener) {
         if (Util.isOverridden(BranchBuildStrategy.class, getClass(), "isAutomaticBuild", SCMSource.class,
                 SCMHead.class, SCMRevision.class, SCMRevision.class, SCMRevision.class, TaskListener.class)) {
-            // modern implementation written to the 2.1.3+ spec
+            // modern implementation written to the 2.4.2+ spec
             return isAutomaticBuild(source, head, currRevision, lastBuiltRevision, lastSeenRevision, listener);
         }
         if (Util.isOverridden(BranchBuildStrategy.class, getClass(), "isAutomaticBuild", SCMSource.class,

--- a/src/main/java/jenkins/branch/BranchBuildStrategy.java
+++ b/src/main/java/jenkins/branch/BranchBuildStrategy.java
@@ -151,10 +151,9 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
      * @param head         the {@link SCMHead}
      * @param currRevision the {@link SCMRevision} that the build head is now at
      * @param lastBuiltRevision the {@link SCMRevision} that the build head was last seen at or {@code null} if this is a newly
-     *                     discovered head. Care should be taken to consider the case of non
-     *                     {@link SCMRevision#isDeterministic()} previous revisions as polling for changes will have
-     *                     confirmed that there is a change between this and {@code currRevision} even if the two
-     *                     are equal.
+     *                     discovered head. It replaces prevRevision from the previous SPI version. Care should be taken to consider
+     *                     the case of non {@link SCMRevision#isDeterministic()} previous revisions as polling for changes will have
+     *                     confirmed that there is a change between this and {@code currRevision} even if the two are equal.
      * @param lastSeenRevision the {@link SCMRevision} that the head was last seen
      * @param listener     the {@link TaskListener} that can be used for outputting any rational for the decision
      * @return {@code true} if and only if the {@link SCMRevision} should be automatically built when the

--- a/src/main/java/jenkins/branch/BranchBuildStrategy.java
+++ b/src/main/java/jenkins/branch/BranchBuildStrategy.java
@@ -165,7 +165,7 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
                                              @NonNull SCMRevision currRevision,
                                              @CheckForNull SCMRevision prevRevision,
                                              @NonNull TaskListener listener,
-                                             @NonNull SCMRevision lastSeenRevision);
+                                             @CheckForNull SCMRevision lastSeenRevision);
 
     /**
      * API: Should the specified {@link SCMRevision} of the {@link SCMHead} for the specified {@link SCMSource} be

--- a/src/main/java/jenkins/branch/BranchBuildStrategy.java
+++ b/src/main/java/jenkins/branch/BranchBuildStrategy.java
@@ -130,12 +130,42 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
      * {@link SCMHead} has been detected as created / modified.
      * @since 2.1.3
      */
+    @Deprecated
+    @SuppressWarnings("deprecation")
+    @Restricted(ProtectedExternally.class)
+    public boolean isAutomaticBuild(@NonNull SCMSource source,
+                                             @NonNull SCMHead head,
+                                             @NonNull SCMRevision currRevision,
+                                             @CheckForNull SCMRevision prevRevision,
+                                             @NonNull TaskListener listener) {
+        throw new UnsupportedOperationException("Modern implementation accessed using legacy API method");
+    }
+
+    /**
+     * SPI: Should the specified {@link SCMRevision} of the {@link SCMHead} for the specified {@link SCMSource} be
+     * triggered when the {@link SCMHead} has been detected as created / modified?
+     *
+     * @param source       the {@link SCMSource}
+     * @param head         the {@link SCMHead}
+     * @param currRevision the {@link SCMRevision} that the build head is now at
+     * @param prevRevision the {@link SCMRevision} that the build head was last seen at or {@code null} if this is a newly
+     *                     discovered head. Care should be taken to consider the case of non
+     *                     {@link SCMRevision#isDeterministic()} previous revisions as polling for changes will have
+     *                     confirmed that there is a change between this and {@code currRevision} even if the two
+     *                     are equal.
+     * @param listener     the {@link TaskListener} that can be used for outputting any rational for the decision
+     * @param lastSeenRevision the {@link SCMRevision} that the head is now at
+     * @return {@code true} if and only if the {@link SCMRevision} should be automatically built when the
+     * {@link SCMHead} has been detected as created / modified.
+     * @since 2.4.2
+     */
     @Restricted(ProtectedExternally.class)
     public abstract boolean isAutomaticBuild(@NonNull SCMSource source,
                                              @NonNull SCMHead head,
                                              @NonNull SCMRevision currRevision,
                                              @CheckForNull SCMRevision prevRevision,
-                                             @NonNull TaskListener listener);
+                                             @NonNull TaskListener listener,
+                                             @NonNull SCMRevision lastSeenRevision);
 
     /**
      * API: Should the specified {@link SCMRevision} of the {@link SCMHead} for the specified {@link SCMSource} be
@@ -184,6 +214,39 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
                                         @NonNull SCMRevision currRevision,
                                         @CheckForNull SCMRevision prevRevision,
                                         @NonNull TaskListener listener) {
+        return automaticBuild(source, head, currRevision, prevRevision, listener, null);
+    }
+
+
+
+    /**
+     * API: Should the specified {@link SCMRevision} of the {@link SCMHead} for the specified {@link SCMSource} be
+     * triggered when the {@link SCMHead} has been detected as created / modified?
+     *
+     * @param source       the {@link SCMSource}
+     * @param head         the {@link SCMHead}
+     * @param currRevision the {@link SCMRevision} that the head is now at
+     * @param prevRevision the {@link SCMRevision} that the head was last seen at or {@code null} if this is a newly
+     *                     discovered head. Care should be taken to consider the case of non
+     *                     {@link SCMRevision#isDeterministic()} previous revisions as polling for changes will have
+     *                     confirmed that there is a change between this and {@code currRevision} even if the two
+     *                     are equal.
+     * @return {@code true} if and only if the {@link SCMRevision} should be automatically built when the
+     * {@link SCMHead} has been detected as created / modified.
+     * @since 2.1.3
+     */
+    @SuppressWarnings("deprecation")
+    public final boolean automaticBuild(@NonNull SCMSource source,
+                                        @NonNull SCMHead head,
+                                        @NonNull SCMRevision currRevision,
+                                        @CheckForNull SCMRevision prevRevision,
+                                        @NonNull TaskListener listener,
+                                        @CheckForNull SCMRevision lastSeenRevision) {
+        if (Util.isOverridden(BranchBuildStrategy.class, getClass(), "isAutomaticBuild", SCMSource.class,
+                SCMHead.class, SCMRevision.class, SCMRevision.class, TaskListener.class, SCMRevision.class)) {
+            // modern implementation written to the 2.1.3+ spec
+            return isAutomaticBuild(source, head, currRevision, prevRevision, listener, lastSeenRevision);
+        }
         if (Util.isOverridden(BranchBuildStrategy.class, getClass(), "isAutomaticBuild", SCMSource.class,
                 SCMHead.class, SCMRevision.class, SCMRevision.class, TaskListener.class)) {
             // modern implementation written to the 2.1.3+ spec
@@ -206,7 +269,7 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
         }
         // this is going to throw an abstract method exception, but we should never get here as all implementations
         // have to at least have overridden one of the methods above.
-        return isAutomaticBuild(source, head, currRevision, prevRevision, listener);
+        return isAutomaticBuild(source, head, currRevision, prevRevision, listener, lastSeenRevision);
     }
 
     /**

--- a/src/main/java/jenkins/branch/BranchProjectFactory.java
+++ b/src/main/java/jenkins/branch/BranchProjectFactory.java
@@ -182,6 +182,35 @@ public abstract class BranchProjectFactory<P extends Job<P, R> & TopLevelItem,
     }
 
     /**
+     * Gets the {@link SCMRevision} that the project was last seen for.
+     *
+     * @param project the project.
+     * @return the {@link SCMRevision} of the last seen.
+     */
+    @CheckForNull
+    public SCMRevision getLasSeenRevision(P project) {
+        XmlFile file = new XmlFile(new File(project.getRootDir(), "scm-last-seen-revision-hash.xml"));
+        try {
+            return (SCMRevision) file.read();
+        } catch (IOException e) {
+            // ignore
+        }
+        return null;
+    }
+
+    /**
+     * Sets the {@link SCMRevision} that the project was last seen
+     *
+     * @param project  the project.
+     * @param revision the {@link SCMRevision} of the last build.
+     * @throws IOException if there was an issue persisting the details.
+     */
+    public void setLastSeenRevisionHash(P project, SCMRevision revision) throws IOException {
+        XmlFile file = new XmlFile(new File(project.getRootDir(), "scm-last-seen-revision-hash.xml"));
+        file.write(revision);
+    }
+
+    /**
      * Decorates the project in with all the {@link JobDecorator} instances.
      * NOTE: This method should suppress saving the project and only affect the in-memory state.
      * NOTE: Override if the default strategy is not appropriate for the specific project type.

--- a/src/main/java/jenkins/branch/BranchProjectFactory.java
+++ b/src/main/java/jenkins/branch/BranchProjectFactory.java
@@ -188,7 +188,7 @@ public abstract class BranchProjectFactory<P extends Job<P, R> & TopLevelItem,
      * @return the {@link SCMRevision} of the last seen.
      */
     @CheckForNull
-    public SCMRevision getLasSeenRevision(P project) {
+    public SCMRevision getLastSeenRevision(P project) {
         XmlFile file = new XmlFile(new File(project.getRootDir(), "scm-last-seen-revision-hash.xml"));
         try {
             return (SCMRevision) file.read();

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -646,7 +646,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         }
     }
 
-    private void scheduleBuild(final P item, TaskListener listener, String name, Cause[] causes, Action... actions) {
+    private void scheduleBuild(BranchProjectFactory<P, R> factory, final P item, SCMRevision revision, TaskListener listener, String name, Cause[] causes, Action... actions) {
         if (!isBuildable()) {
             listener.getLogger().printf("Did not schedule build for branch: %s (%s is disabled)%n",
                     name, getDisplayName());
@@ -683,6 +683,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         }
         if (ParameterizedJobMixIn.scheduleBuild2(item, 0, _actions) != null) {
             listener.getLogger().println("Scheduled build for branch: " + name);
+            try {
+                factory.setRevisionHash(item, revision);
+            } catch (IOException e) {
+                printStackTrace(e, listener.error("Could not update last revision hash"));
+            }
         } else {
             listener.getLogger().println("Did not schedule build for branch: " + name);
         }
@@ -2051,9 +2056,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         // the previous "revision" for this head is not a revision for the current source
                         // either because the head was removed and then recreated, or because the head
                         // was taken over by a different source, thus the previous revision is null
-                        if (isAutomaticBuild(source, head, revision, null, listener)) {
+                        if (isAutomaticBuild(source, head, revision, null, listener, null)) {
                             scheduleBuild(
+                                    _factory,
                                     project,
+                                    revision,
                                     listener,
                                     rawName,
                                     causeFactory.create(source),
@@ -2063,19 +2070,22 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                             listener.getLogger().format("No automatic builds for %s%n", rawName);
                         }
                         try {
-                            _factory.setRevisionHash(project, revision);
+                            _factory.setLastSeenRevisionHash(project, revision);
                         } catch (IOException e) {
                             printStackTrace(e, listener.error("Could not update last revision hash"));
                         }
                     } else if (revision.isDeterministic()) {
                         SCMRevision prevRevision = _factory.getRevision(project);
+                        SCMRevision scmLastSeenRevision = _factory.getLasSeenRevision(project);
                         if (!revision.equals(prevRevision)) {
                             listener.getLogger()
                                     .format("Changes detected: %s (%s → %s)%n", rawName, prevRevision, revision);
                             needSave = true;
-                            if (isAutomaticBuild(source, head, revision, prevRevision, listener)) {
+                            if (isAutomaticBuild(source, head, revision, prevRevision, listener, scmLastSeenRevision)) {
                                 scheduleBuild(
+                                        _factory,
                                         project,
+                                        revision,
                                         listener,
                                         rawName,
                                         causeFactory.create(source),
@@ -2085,7 +2095,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 listener.getLogger().format("No automatic builds for %s%n", rawName);
                             }
                             try {
-                                _factory.setRevisionHash(project, revision);
+                                _factory.setLastSeenRevisionHash(project, revision);
                             } catch (IOException e) {
                                 printStackTrace(e, listener.error("Could not update last revision hash"));
                             }
@@ -2110,9 +2120,12 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 needSave = true;
                                 // get the previous revision
                                 SCMRevision prevRevision = _factory.getRevision(project);
-                                if (isAutomaticBuild(source, head, revision, prevRevision, listener)) {
+                                SCMRevision scmLastSeenRevision = _factory.getLasSeenRevision(project);
+                                if (isAutomaticBuild(source, head, revision, prevRevision, listener, scmLastSeenRevision)) {
                                     scheduleBuild(
+                                            _factory,
                                             project,
+                                            revision,
                                             listener,
                                             rawName,
                                             causeFactory.create(source),
@@ -2122,7 +2135,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                     listener.getLogger().format("No automatic builds for %s%n", rawName);
                                 }
                                 try {
-                                    _factory.setRevisionHash(project, revision);
+                                    _factory.setLastSeenRevisionHash(project, revision);
                                 } catch (IOException e) {
                                     printStackTrace(e, listener.error("Could not update last revision hash"));
                                 }
@@ -2177,9 +2190,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 _factory.decorate(project);
                 // ok it is now up to the observer to ensure it does the actual save.
                 observer.created(project);
-                if (isAutomaticBuild(source, head, revision, null, listener)) {
+                if (isAutomaticBuild(source, head, revision, null, listener, null)) {
                     scheduleBuild(
+                            _factory,
                             project,
+                            revision,
                             listener,
                             rawName,
                             causeFactory.create(source),
@@ -2189,7 +2204,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     listener.getLogger().format("No automatic builds for %s%n", rawName);
                 }
                 try {
-                    _factory.setRevisionHash(project, revision);
+                    _factory.setLastSeenRevisionHash(project, revision);
                 } catch (IOException e) {
                     printStackTrace(e, listener.error("Could not update last revision hash"));
                 }
@@ -2203,14 +2218,18 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
      * Tests if the specified {@link SCMHead} should be automatically built when discovered / modified.
      * @param source the source.
      * @param head the head.
-     * @param currRevision the revision.
+     * @param currRevision the current built revision.
+     * @param prevRevision the previous built revision
+     * @param listener the {@link TaskListener}
+     * @param lastSeenRevision the last seen revision
      * @return {@code true} if the head should be automatically built when discovered / modified.
      */
     private boolean isAutomaticBuild(@NonNull SCMSource source,
                                      @NonNull SCMHead head,
                                      @NonNull SCMRevision currRevision,
                                      @CheckForNull SCMRevision prevRevision,
-                                     @NonNull TaskListener listener) {
+                                     @NonNull TaskListener listener,
+                                     @CheckForNull SCMRevision lastSeenRevision) {
         BranchSource branchSource = null;
         for (BranchSource s: sources) {
             if (s.getSource().getId().equals(source.getId())) {
@@ -2228,7 +2247,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
             return !(head instanceof TagSCMHead);
         } else {
             for (BranchBuildStrategy s: buildStrategies) {
-                if (s.automaticBuild(source, head, currRevision, prevRevision, listener)) {
+                if (s.automaticBuild(source, head, currRevision, prevRevision, listener, lastSeenRevision)) {
                     return true;
                 }
             }

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -2076,7 +2076,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         }
                     } else if (revision.isDeterministic()) {
                         SCMRevision scmLastBuiltRevision = _factory.getRevision(project);
-                        SCMRevision scmLastSeenRevision = _factory.getLasSeenRevision(project);
+                        SCMRevision scmLastSeenRevision = _factory.getLastSeenRevision(project);
                         if (!revision.equals(scmLastSeenRevision)) {
                             listener.getLogger()
                                     .format("Changes detected: %s (%s → %s)%n", rawName, scmLastSeenRevision, revision);
@@ -2120,7 +2120,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 needSave = true;
                                 // get the previous revision
                                 SCMRevision scmLastBuiltRevision = _factory.getRevision(project);
-                                SCMRevision scmLastSeenRevision = _factory.getLasSeenRevision(project);
+                                SCMRevision scmLastSeenRevision = _factory.getLastSeenRevision(project);
                                 if (isAutomaticBuild(source, head, revision, scmLastBuiltRevision, scmLastSeenRevision, listener)) {
                                     scheduleBuild(
                                             _factory,

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -2072,7 +2072,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         try {
                             _factory.setLastSeenRevisionHash(project, revision);
                         } catch (IOException e) {
-                            printStackTrace(e, listener.error("Could not update last revision hash"));
+                            printStackTrace(e, listener.error("Could not update last seen revision hash"));
                         }
                     } else if (revision.isDeterministic()) {
                         SCMRevision prevRevision = _factory.getRevision(project);
@@ -2097,7 +2097,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                             try {
                                 _factory.setLastSeenRevisionHash(project, revision);
                             } catch (IOException e) {
-                                printStackTrace(e, listener.error("Could not update last revision hash"));
+                                printStackTrace(e, listener.error("Could not update last seen revision hash"));
                             }
                         } else {
                             listener.getLogger().format("No changes detected: %s (still at %s)%n", rawName, revision);
@@ -2137,7 +2137,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 try {
                                     _factory.setLastSeenRevisionHash(project, revision);
                                 } catch (IOException e) {
-                                    printStackTrace(e, listener.error("Could not update last revision hash"));
+                                    printStackTrace(e, listener.error("Could not update last seen revision hash"));
                                 }
                             } else {
                                 listener.getLogger().format("No changes detected: %s%n", rawName);
@@ -2206,7 +2206,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 try {
                     _factory.setLastSeenRevisionHash(project, revision);
                 } catch (IOException e) {
-                    printStackTrace(e, listener.error("Could not update last revision hash"));
+                    printStackTrace(e, listener.error("Could not update last seen revision hash"));
                 }
             } finally {
                 observer.completed(encodedName);

--- a/src/test/java/integration/EventsTest.java
+++ b/src/test/java/integration/EventsTest.java
@@ -642,7 +642,8 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision, TaskListener listener, SCMRevision lastSeenRevision) {
+                                        SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision,
+                                        TaskListener listener) {
             return true;
         }
 
@@ -692,8 +693,8 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision,
-                                        @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
+                                        SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision,
+                                        @NonNull TaskListener listener) {
             return head instanceof ChangeRequestSCMHead;
         }
 
@@ -708,7 +709,8 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision, @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
+                                        SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision,
+                                        @NonNull TaskListener listener) {
             if (head instanceof ChangeRequestSCMHead) {
                 try {
                     return currRevision.equals(source.getTrustedRevision(currRevision, listener));
@@ -1026,8 +1028,8 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision,
-                                        @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
+                                        SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision,
+                                        @NonNull TaskListener listener) {
             return currRevision instanceof MockSCMRevision
                     && approved.contains(((MockSCMRevision) currRevision).getHash());
         }
@@ -1092,12 +1094,13 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision, @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
+                                        SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision,
+                                        @NonNull TaskListener listener) {
             if (currRevision instanceof ChangeRequestSCMRevision) {
                 ChangeRequestSCMRevision<?> currCR = (ChangeRequestSCMRevision<?>) currRevision;
-                if (prevRevision instanceof ChangeRequestSCMRevision) {
+                if (lastBuiltRevision instanceof ChangeRequestSCMRevision) {
                     // if we have a previous, only build if the change is affecting the head not the target
-                    return !currCR.equivalent((ChangeRequestSCMRevision<?>) prevRevision);
+                    return !currCR.equivalent((ChangeRequestSCMRevision<?>) lastBuiltRevision);
                 } else {
                     // we don't have a previous, so build
                     return true;

--- a/src/test/java/integration/EventsTest.java
+++ b/src/test/java/integration/EventsTest.java
@@ -642,7 +642,7 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision, TaskListener listener) {
+                                        SCMRevision prevRevision, TaskListener listener, SCMRevision lastSeenRevision) {
             return true;
         }
 
@@ -693,7 +693,7 @@ public class EventsTest {
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
                                         SCMRevision prevRevision,
-                                        @NonNull TaskListener listener) {
+                                        @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
             return head instanceof ChangeRequestSCMHead;
         }
 
@@ -708,7 +708,7 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision, @NonNull TaskListener listener) {
+                                        SCMRevision prevRevision, @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
             if (head instanceof ChangeRequestSCMHead) {
                 try {
                     return currRevision.equals(source.getTrustedRevision(currRevision, listener));
@@ -1027,7 +1027,7 @@ public class EventsTest {
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
                                         SCMRevision prevRevision,
-                                        @NonNull TaskListener listener) {
+                                        @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
             return currRevision instanceof MockSCMRevision
                     && approved.contains(((MockSCMRevision) currRevision).getHash());
         }
@@ -1092,7 +1092,7 @@ public class EventsTest {
         @Override
         public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
                                         @NonNull SCMRevision currRevision,
-                                        SCMRevision prevRevision, @NonNull TaskListener listener) {
+                                        SCMRevision prevRevision, @NonNull TaskListener listener, SCMRevision lastSeenRevision) {
             if (currRevision instanceof ChangeRequestSCMRevision) {
                 ChangeRequestSCMRevision<?> currCR = (ChangeRequestSCMRevision<?>) currRevision;
                 if (prevRevision instanceof ChangeRequestSCMRevision) {

--- a/src/test/java/integration/EventsTest.java
+++ b/src/test/java/integration/EventsTest.java
@@ -113,6 +113,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 import org.junit.Ignore;
@@ -2757,6 +2760,72 @@ public class EventsTest {
                     is("bar:id"));
             r.waitUntilNoActivity();
             assertThat("The feature branch was rebuilt", feature.getLastBuild().getNumber(), is(2));
+        }
+    }
+
+    @Test
+    public void given_multibranch_when_not_build_is_skipped_then_lastSeenRevision_is_equal_to_lastBuiltRevision() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("foo");
+            BasicMultiBranchProject prj = r.jenkins.createProject(BasicMultiBranchProject.class, "my-project");
+            prj.setCriteria(null);
+            prj.getSourcesList().add(new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches())));
+            fire(new MockSCMHeadEvent(SCMEvent.Type.CREATED, c, "foo", "master", c.getRevision("foo", "master")));
+            FreeStyleProject master = prj.getItem("master");
+            r.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild().getNumber(), is(1));
+            assertEquals(prj.getProjectFactory().getLastSeenRevision(master), prj.getProjectFactory().getRevision(master));
+            c.addFile("foo", "master", "adding file", "file", new byte[0]);
+            fire(new MockSCMHeadEvent(SCMEvent.Type.UPDATED, c, "foo", "master", c.getRevision("foo", "master")));
+            r.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild(), notNullValue());
+            assertThat("The master branch was built", master.getLastBuild().getNumber(), is(2));
+            assertEquals(prj.getProjectFactory().getLastSeenRevision(master), prj.getProjectFactory().getRevision(master));
+        }
+    }
+
+    @Test
+    public void given_multibranch_when_build_is_skipped_then_lastSeenRevision_is_different_to_lastBuiltRevision() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("foo");
+            BasicMultiBranchProject prj = r.jenkins.createProject(BasicMultiBranchProject.class, "my-project");
+            prj.setCriteria(null);
+            BranchSource source = new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches()));
+            source.setBuildStrategies(Collections.<BranchBuildStrategy>singletonList(new SkipInitialBuildStrategyImpl()));
+            prj.getSourcesList().add(source);
+            fire(new MockSCMHeadEvent(SCMEvent.Type.CREATED, c, "foo", "master", c.getRevision("foo", "master")));
+            FreeStyleProject master = prj.getItem("master");
+            r.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild(), nullValue());
+            assertNotNull(prj.getProjectFactory().getLastSeenRevision(master));
+            assertNull(prj.getProjectFactory().getRevision(master));
+            c.addFile("foo", "master", "adding file", "file", new byte[0]);
+            fire(new MockSCMHeadEvent(SCMEvent.Type.UPDATED, c, "foo", "master", c.getRevision("foo", "master")));
+            r.waitUntilNoActivity();
+            assertThat("The master branch was built", master.getLastBuild(), notNullValue());
+            assertThat("The master branch was built", master.getLastBuild().getNumber(), is(1));
+            assertNotNull(prj.getProjectFactory().getLastSeenRevision(master));
+            assertNotNull(prj.getProjectFactory().getRevision(master));
+            assertThat(prj.getProjectFactory().getRevision(master), is(prj.getProjectFactory().getLastSeenRevision(master)));
+        }
+    }
+
+    public static class SkipInitialBuildStrategyImpl extends BranchBuildStrategy {
+        @Override
+        public boolean isAutomaticBuild(@NonNull SCMSource source, @NonNull SCMHead head,
+                                        @NonNull SCMRevision currRevision,
+                                        SCMRevision lastBuiltRevision, SCMRevision lastSeenRevision,
+                                        TaskListener listener) {
+           if (lastSeenRevision != null) {
+               return true;
+           }
+           return false;
+        }
+
+        @TestExtension(
+                "given_multibranch_when_build_is_skipped_then_lastSeenRevision_is_different_to_lastBuiltRevision")
+        public static class DescriptorImpl extends BranchBuildStrategyDescriptor {
+
         }
     }
 


### PR DESCRIPTION
This is a follow-up of the conversation in #144 

To keep the compatibility with custom plugins which might rely on setRevision being set at build time, I am adding a setLastSeenRevision to also being able to track the current revision.

CC @stephenc @rsandell @Alex-Vol-SV