### PR TITLE
[JENKINS-54992] Do not override pronoun on projects only on their scan

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -302,10 +302,10 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     }
 
     /**
-     * {@inheritDoc}
+     * Get the term used in the UI to represent the souce for this kind of
+     * {@link Item}. Must start with a capital letter.
      */
-    @Override
-    public String getPronoun() {
+    public String getSourcePronoun() {
         Set<String> result = new TreeSet<>();
         for (BranchSource source : sources) {
             String pronoun = Util.fixEmptyAndTrim(source.getSource().getPronoun());
@@ -313,7 +313,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 result.add(pronoun);
             }
         }
-        return result.isEmpty() ? super.getPronoun() : StringUtils.join(result, " / ");
+        return result.isEmpty() ? this.getPronoun() : StringUtils.join(result, " / ");
     }
 
     /**
@@ -993,7 +993,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
          */
         @Override
         public String getDisplayName() {
-            return Messages.MultiBranchProject_BranchIndexing_displayName(getParent().getPronoun());
+            return Messages.MultiBranchProject_BranchIndexing_displayName(getParent().getSourcePronoun());
         }
 
         /**

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -533,10 +533,10 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
     }
 
     /**
-     * {@inheritDoc}
+     * Get the term used in the UI to represent the souce for this kind of
+     * {@link Item}. Must start with a capital letter.
      */
-    @Override
-    public String getPronoun() {
+    public String getSourcePronoun() {
         Set<String> result = new TreeSet<>();
         for (SCMNavigator navigator: navigators) {
             String pronoun = Util.fixEmptyAndTrim(navigator.getPronoun());
@@ -544,7 +544,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                 result.add(pronoun);
             }
         }
-        return result.isEmpty() ? super.getPronoun() : StringUtils.join(result, " / ");
+        return result.isEmpty() ? this.getPronoun() : StringUtils.join(result, " / ");
     }
 
     /**
@@ -922,7 +922,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
          */
         @Override
         public String getDisplayName() {
-            return Messages.OrganizationFolder_OrganizationScan_displayName(getParent().getPronoun());
+            return Messages.OrganizationFolder_OrganizationScan_displayName(((OrganizationFolder)getParent()).getSourcePronoun());
         }
 
         @Override


### PR DESCRIPTION
This issue shows that changing the pronoun on a project in
in order to make some actions by the project more clear is
actually problematic.  

As reasonable fix, this change makes
the indexing use the source pronoun(s) while reverting the
projects to using their original pronouns.

This PR came from discussions around
https://github.com/jenkinsci/github-branch-source-plugin/pull/195

After this change the Multibranch Pipeline looks like this: 
<img width="282" alt="Screen Shot 2019-04-16 at 6 16 36 PM" src="https://user-images.githubusercontent.com/1958953/56254227-c6d79200-6074-11e9-909e-0d377042dfc7.png">

A github organization folder looks like this:
<img width="255" alt="Screen Shot 2019-04-16 at 6 24 25 PM" src="https://user-images.githubusercontent.com/1958953/56254278-fdada800-6074-11e9-9bf9-0a2838cfd80b.png">

