### PR TITLE
[JENKINS-49729] Add some css to job and run pages for dead branches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <jenkins.version>2.138</jenkins.version>
     <java.level>8</java.level>
     <scm-api.version>2.4.1</scm-api.version>
-    <git-plugin.version>4.0.0-rc</git-plugin.version>
+    <git-plugin.version>3.10.0</git-plugin.version>
   </properties>
 
   <repositories>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.10</version>
+      <version>1.18</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
+      <version>1.27</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <jenkins.version>2.138</jenkins.version>
     <java.level>8</java.level>
     <scm-api.version>2.4.1</scm-api.version>
-    <git-plugin.version>3.10.0</git-plugin.version>
+    <git-plugin.version>4.0.0-rc</git-plugin.version>
   </properties>
 
   <repositories>
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.18</version>
+      <version>1.10</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.27</version>
+      <version>1.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/jenkins/branch/DeadBranchIndicatorAction.java
+++ b/src/main/java/jenkins/branch/DeadBranchIndicatorAction.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.branch;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.model.TransientActionFactory;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * An action that puts some css on job and run pages for jobs representing {@link Branch.Dead}.
+ */
+public class DeadBranchIndicatorAction implements Action {
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    @Extension
+    public static class JobFactoryImpl extends TransientActionFactory<Job> {
+
+        @Override
+        public Class<Job> type() {
+            return Job.class;
+        }
+
+        @Nonnull
+        @Override
+        public Collection<? extends Action> createFor(@Nonnull Job job) {
+            if (job.getParent() instanceof MultiBranchProject) {
+                MultiBranchProject p = (MultiBranchProject) job.getParent();
+                BranchProjectFactory factory = p.getProjectFactory();
+                if (factory.isProject(job)) {
+                    Branch b = factory.getBranch(factory.asProject(job));
+                    if (b instanceof Branch.Dead) {
+                        return Collections.singleton(new DeadBranchIndicatorAction());
+                    }
+                }
+            }
+            return Collections.emptyList();
+        }
+    }
+
+    @Extension
+    public static class RunFactoryImpl extends TransientActionFactory<Run> {
+
+        @Override
+        public Class<Run> type() {
+            return Run.class;
+        }
+
+        @Nonnull
+        @Override
+        public Collection<? extends Action> createFor(@Nonnull Run target) {
+            final Job job = target.getParent();
+            if (job.getParent() instanceof MultiBranchProject) {
+                MultiBranchProject p = (MultiBranchProject) job.getParent();
+                BranchProjectFactory factory = p.getProjectFactory();
+                if (factory.isProject(job)) {
+                    Branch b = factory.getBranch(factory.asProject(job));
+                    if (b instanceof Branch.Dead) {
+                        return Collections.singleton(new DeadBranchIndicatorAction());
+                    }
+                }
+            }
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/jenkins/branch/DeadBranchIndicatorAction.java
+++ b/src/main/java/jenkins/branch/DeadBranchIndicatorAction.java
@@ -25,7 +25,10 @@ package jenkins.branch;
 
 import hudson.Extension;
 import hudson.model.Action;
+import hudson.model.BallColor;
+import hudson.model.InvisibleAction;
 import hudson.model.Job;
+import hudson.model.Result;
 import hudson.model.Run;
 import jenkins.model.TransientActionFactory;
 
@@ -37,23 +40,10 @@ import java.util.Collections;
 /**
  * An action that puts some css on job and run pages for jobs representing {@link Branch.Dead}.
  */
-public class DeadBranchIndicatorAction implements Action {
-    @CheckForNull
-    @Override
-    public String getIconFileName() {
-        return null;
-    }
+public class DeadBranchIndicatorAction extends InvisibleAction {
 
-    @CheckForNull
-    @Override
-    public String getDisplayName() {
-        return null;
-    }
-
-    @CheckForNull
-    @Override
-    public String getUrlName() {
-        return null;
+    public String getDisabledColor() {
+        return BallColor.DISABLED.getHtmlBaseColor();
     }
 
     @Extension

--- a/src/main/resources/jenkins/branch/DeadBranchIndicatorAction/jobMain.jelly
+++ b/src/main/resources/jenkins/branch/DeadBranchIndicatorAction/jobMain.jelly
@@ -1,0 +1,43 @@
+<!--
+The MIT License
+
+Copyright (c) 2019 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <!--TODO build-caption i.e. the links to the builds on the job page doesn't take effect-->
+    <style type="text/css">
+        a.build-link {
+            text-decoration: line-through;
+            color: silver;
+        }
+        h1.job-index-headline {
+            text-decoration: line-through;
+            color: silver;
+        }
+        h1.build-caption {
+            text-decoration: line-through;
+            color: silver;
+        }
+    </style>
+</j:jelly>

--- a/src/main/resources/jenkins/branch/DeadBranchIndicatorAction/summary.jelly
+++ b/src/main/resources/jenkins/branch/DeadBranchIndicatorAction/summary.jelly
@@ -26,20 +26,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <j:set var="disabledColor" value="${it.disabledColor}"/>
+    <!--TODO build-link i.e. the links to the builds on the job page doesn't take effect-->
     <style type="text/css">
-        .pane.build-name a {
-            text-decoration: line-through;
-            color: ${disabledColor};
-        }
-        .pane.build-name a:visited {
-            text-decoration: line-through;
-            color: ${disabledColor};
-        }
-        .pane.build-name a:active {
-            text-decoration: line-through;
-            color: ${disabledColor};
-        }
-        h1.job-index-headline {
+        h1.build-caption {
             text-decoration: line-through;
             color: ${disabledColor};
         }


### PR DESCRIPTION
Also had to tweak the dependencies a bit since the introduction of
git 4.0.0-rc broke hpi:run

**Before**
    *Job Page*
![JENKINS-49729-BEFORE](https://user-images.githubusercontent.com/300688/57523061-3feca100-7324-11e9-8b54-29e3830b3496.png)
*Except for the "This job is currently disabled" message which was still there before*

    *Build Page*
![JENKINS-49729-BEFORE-build](https://user-images.githubusercontent.com/300688/57523097-572b8e80-7324-11e9-879a-cc027761b8b1.png)

**After**
    *Job Page*
![JENKINS-49729-AFTER-job](https://user-images.githubusercontent.com/300688/57523128-6ca0b880-7324-11e9-8c7b-92a0490c9112.png)
    *Build Page*
![JENKINS-49729-AFTER-build](https://user-images.githubusercontent.com/300688/57523185-95c14900-7324-11e9-84f1-6f811d228760.png)
