### PR TITLE
Fix missing message variable change

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -2089,7 +2089,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         }
                         if (!revision.equals(scmLastBuiltRevision)) {
                             listener.getLogger()
-                                    .format("Changes detected: %s (%s → %s)%n", rawName, scmLastSeenRevision, revision);
+                                    .format("Changes detected: %s (%s → %s)%n", rawName, scmLastBuiltRevision, revision);
                             needSave = true;
                             if (isAutomaticBuild(source, head, revision, scmLastBuiltRevision, scmLastSeenRevision, listener)) {
                                 scheduleBuild(


### PR DESCRIPTION
In #152 we missed a second use of the variable, so display is wrong.

```
  Getting remote pull requests...
      ‘Jenkinsfile’ found
    Met criteria
Changes detected: master (bc1bf622bedeb9a04debfa2236620eb0edac6dc6 → bc1bf622bedeb9a04debfa2236620eb0edac6dc6)
No automatic builds for master
```