### PR TITLE
[JENKINS-39682] trigger after-save hooks and recalculate

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -235,6 +235,12 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 }
             }
         }
+        if (Items.currentlyUpdatingByXml()) {
+            fireSCMSourceAfterSave(getSCMSources());
+            if (isBuildable()) {
+                scheduleBuild();
+            }
+        }
     }
 
     /**

--- a/src/test/java/integration/UpdatingFromXmlTest.java
+++ b/src/test/java/integration/UpdatingFromXmlTest.java
@@ -1,0 +1,62 @@
+package integration;
+
+import hudson.model.TopLevelItem;
+import integration.harness.BasicMultiBranchProject;
+import jenkins.scm.impl.mock.MockSCMController;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.ReaderInputStream;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import java.io.StringReader;
+
+import static junit.framework.TestCase.assertTrue;
+
+public class UpdatingFromXmlTest {
+
+    /**
+     * All tests in this class only create items and do not affect other global configuration, thus we trade test
+     * execution time for the restriction on only touching items.
+     */
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
+
+    @Before
+    public void cleanOutAllItems() throws Exception {
+        for (TopLevelItem i : r.getInstance().getItems()) {
+            i.delete();
+        }
+    }
+
+    @Test
+    public void given_multibranch_when_createFromXml_then_hasItems() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("foo");
+            c.cloneBranch("foo", "master", "feature");
+            c.addFile("foo", "feature", "add new feature", "FEATURE", "new".getBytes());
+            String configXml = IOUtils.toString(getClass().getResourceAsStream("UpdatingFromXmlTest/config.xml")).replace("fixme", c.getId());
+            BasicMultiBranchProject prj = (BasicMultiBranchProject) r.jenkins.createProjectFromXML("foo", new ReaderInputStream(new StringReader(configXml)));
+            r.waitUntilNoActivity();
+            assertTrue(prj.getItems().size() > 0);
+        }
+    }
+
+    @Test
+    public void given_multibranch_when_upateFromXml_then_hasItems() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("foo");
+            c.cloneBranch("foo", "master", "feature");
+            c.addFile("foo", "feature", "add new feature", "FEATURE", "new".getBytes());
+            String configXml = IOUtils.toString(getClass().getResourceAsStream("UpdatingFromXmlTest/config.xml")).replace("fixme", c.getId());
+            BasicMultiBranchProject prj = r.jenkins.createProject(BasicMultiBranchProject.class, "foo");
+            prj.updateByXml((Source) new StreamSource(new StringReader(configXml)));
+            r.waitUntilNoActivity();
+            assertTrue(prj.getItems().size() > 0);
+        }
+    }
+
+}

--- a/src/test/resources/integration/UpdatingFromXmlTest/config.xml
+++ b/src/test/resources/integration/UpdatingFromXmlTest/config.xml
@@ -1,0 +1,43 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<integration.harness.BasicMultiBranchProject>
+    <properties/>
+    <folderViews class="jenkins.branch.MultiBranchProjectViewHolder">
+        <owner class="integration.harness.BasicMultiBranchProject" reference="../.."/>
+    </folderViews>
+    <healthMetrics>
+        <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+            <nonRecursive>false</nonRecursive>
+        </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+    </healthMetrics>
+    <icon class="jenkins.branch.MetadataActionFolderIcon">
+        <owner class="integration.harness.BasicMultiBranchProject" reference="../.."/>
+    </icon>
+    <orphanedItemStrategy class="com.cloudbees.hudson.plugins.folder.computed.DefaultOrphanedItemStrategy">
+        <pruneDeadBranches>true</pruneDeadBranches>
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>-1</numToKeep>
+    </orphanedItemStrategy>
+    <triggers/>
+    <disabled>false</disabled>
+    <sources class="jenkins.branch.MultiBranchProject$BranchSourceList">
+        <data>
+            <jenkins.branch.BranchSource>
+                <source class="jenkins.scm.impl.mock.MockSCMSource">
+                    <controllerId>fixme</controllerId>
+                    <repository>foo</repository>
+                    <traits>
+                        <jenkins.scm.impl.mock.MockSCMDiscoverBranches/>
+                        <jenkins.scm.impl.mock.MockSCMDiscoverTags/>
+                        <jenkins.scm.impl.mock.MockSCMDiscoverChangeRequests>
+                            <strategies class="enum-set" enum-type="jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy">HEAD</strategies>
+                        </jenkins.scm.impl.mock.MockSCMDiscoverChangeRequests>
+                    </traits>
+                </source>
+            </jenkins.branch.BranchSource>
+        </data>
+        <owner class="integration.harness.BasicMultiBranchProject" reference="../.."/>
+    </sources>
+    <factory class="integration.harness.BasicBranchProjectFactory">
+        <owner class="integration.harness.BasicMultiBranchProject" reference="../.."/>
+    </factory>
+</integration.harness.BasicMultiBranchProject>


### PR DESCRIPTION
 ... after `createProjectFromXML` or `updateByXml`.

See [JENKINS-39682](https://issues.jenkins-ci.org/browse/JENKINS-39682?focusedCommentId=369197&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-369197).