### PR TITLE
JENKINS-58177 - replace leading hyphen in mnemonic of ws path

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -191,6 +191,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                 String mnemonic = mnemonicOf(fullName);
                 for (int i = 1; ; i++) {
                     path = StringUtils.right(i > 1 ? mnemonic + "_" + i : mnemonic, MAX_LENGTH);
+                    path = replaceLeadingHyphen(path);
                     if (index.values().contains(path)) {
                         LOGGER.log(Level.FINER, "index collision on {0} for {1} on {2}", new Object[] {path, item, node});
                     } else {
@@ -298,6 +299,11 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
     private static String mnemonicOf(String name) {
         // Do not need the complexity of NameMangler here, since we uniquify as needed.
         return name.replaceAll("(%[0-9A-F]{2}|[^a-zA-Z0-9-_.])+", "_");
+    }
+
+    private static String replaceLeadingHyphen(String name) {
+        //On linux - or -- (hyphen) are interpreted as an option passed to commands and require special handling. So a leading - is replaced with _.
+        return name.replaceAll("^-", "_");
     }
 
     @Deprecated

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -229,7 +229,7 @@ public class WorkspaceLocatorImplTest {
         s.toComputer().getLogText().writeLogTo(0, System.out);
     }
 
-    @Issue("JENKINS-2111")
+    @Issue({"JENKINS-2111", "JENKINS-58177"})
     @Test
     public void uniquification() throws Exception {
         WorkspaceLocatorImpl.MODE = WorkspaceLocatorImpl.Mode.ENABLED;
@@ -238,6 +238,7 @@ public class WorkspaceLocatorImplTest {
         assertEquals("ch_to_fit_in_a_short_path_at_all", r.buildAndAssertSuccess(r.createFreeStyleProject("way too much to fit in a short path at all")).getWorkspace().getName());
         assertEquals("_to_fit_in_a_short_path_at_all_2", r.buildAndAssertSuccess(r.createFreeStyleProject("really way too much to fit in a short path at all")).getWorkspace().getName());
         assertEquals("_to_fit_in_a_short_path_at_all_3", r.buildAndAssertSuccess(r.createFreeStyleProject("way, way, way too much to fit in a short path at all")).getWorkspace().getName());
+        assertEquals("_-__that_would_start_with_hyphen", r.buildAndAssertSuccess(r.createFreeStyleProject("mnemonic--__that_would_start_with_hyphen")).getWorkspace().getName());
         r.jenkins.getRootPath().child("workspace/" + WorkspaceLocatorImpl.INDEX_FILE_NAME).copyTo(System.out);
     }
 
@@ -267,10 +268,10 @@ public class WorkspaceLocatorImplTest {
     @Test
     public void collisions() throws Exception {
         WorkspaceLocatorImpl.MODE = WorkspaceLocatorImpl.Mode.ENABLED;
-        FilePath firstWs = r.buildAndAssertSuccess(r.createFreeStyleProject("first-project-with-a-rather-long-name")).getWorkspace();
-        assertEquals("-project-with-a-rather-long-name", firstWs.getName());
+        FilePath firstWs = r.buildAndAssertSuccess(r.createFreeStyleProject("first_project-with-a-rather-long-name")).getWorkspace();
+        assertEquals("_project-with-a-rather-long-name", firstWs.getName());
         firstWs.deleteRecursive();
-        assertEquals("roject-with-a-rather-long-name_2", r.buildAndAssertSuccess(r.createFreeStyleProject("second-project-with-a-rather-long-name")).getWorkspace().getName());
+        assertEquals("roject-with-a-rather-long-name_2", r.buildAndAssertSuccess(r.createFreeStyleProject("second_project-with-a-rather-long-name")).getWorkspace().getName());
     }
 
     @Issue({"JENKINS-54654", "JENKINS-54968"})

--- a/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
+++ b/src/test/java/jenkins/branch/WorkspaceLocatorImplTest.java
@@ -268,10 +268,10 @@ public class WorkspaceLocatorImplTest {
     @Test
     public void collisions() throws Exception {
         WorkspaceLocatorImpl.MODE = WorkspaceLocatorImpl.Mode.ENABLED;
-        FilePath firstWs = r.buildAndAssertSuccess(r.createFreeStyleProject("first_project-with-a-rather-long-name")).getWorkspace();
+        FilePath firstWs = r.buildAndAssertSuccess(r.createFreeStyleProject("first-project-with-a-rather-long-name")).getWorkspace();
         assertEquals("_project-with-a-rather-long-name", firstWs.getName());
         firstWs.deleteRecursive();
-        assertEquals("roject-with-a-rather-long-name_2", r.buildAndAssertSuccess(r.createFreeStyleProject("second_project-with-a-rather-long-name")).getWorkspace().getName());
+        assertEquals("roject-with-a-rather-long-name_2", r.buildAndAssertSuccess(r.createFreeStyleProject("second-project-with-a-rather-long-name")).getWorkspace().getName());
     }
 
     @Issue({"JENKINS-54654", "JENKINS-54968"})


### PR DESCRIPTION
[JENKINS-58177](https://issues.jenkins-ci.org/browse/JENKINS-58177)

This is pull requests replaces a leading hyphen in shortened workspace paths which lead to various problems in linux bash.

i also had to change another tests which is affected by this.