### PR TITLE
Support markup formatter in description column

### DIFF
--- a/src/main/java/jenkins/branch/DescriptionColumn.java
+++ b/src/main/java/jenkins/branch/DescriptionColumn.java
@@ -76,12 +76,12 @@ public class DescriptionColumn extends ListViewColumn {
      *
      * @param p   the metadata action.
      * @param job the job.
-     * @return the description.
+     * @return the description. It is never unfiltered, unescaped HTML.
      * @throws IOException if there was an issue encoding the description.
      */
     @Restricted(NoExternalUse.class)
     @SuppressWarnings("unused") // used via Jelly EL binding
-    public String description(@CheckForNull Object p, @NonNull Object job) throws IOException {
+    public String formattedDescription(@CheckForNull Object p, @NonNull Object job) throws IOException {
         if (p instanceof ObjectMetadataAction) {
             // when the description comes from the metadata, assume plain text and use Util.escape
             String objectDescription = ((ObjectMetadataAction) p).getObjectDescription();

--- a/src/main/java/jenkins/branch/DescriptionColumn.java
+++ b/src/main/java/jenkins/branch/DescriptionColumn.java
@@ -72,7 +72,7 @@ public class DescriptionColumn extends ListViewColumn {
     }
 
     /**
-     * Gets the description of a job.
+     * Gets the formatted description of a job.
      *
      * @param p   the metadata action.
      * @param job the job.

--- a/src/main/resources/jenkins/branch/DescriptionColumn/column.jelly
+++ b/src/main/resources/jenkins/branch/DescriptionColumn/column.jelly
@@ -4,10 +4,10 @@
     <j:set var="p" value="${col.getPropertyOf(job)}"/>
     <j:choose>
       <j:when test="${p != null and p.objectUrl != null}">
-        <a href="${p.objectUrl}">${col.description(p,job)}</a>
+        <a href="${p.objectUrl}"><j:out value="${col.description(p,job)}"/></a>
       </j:when>
       <j:otherwise>
-        ${col.description(p, job)}
+        <j:out value="${col.description(p, job)}"/>
       </j:otherwise>
     </j:choose>
   </td>

--- a/src/main/resources/jenkins/branch/DescriptionColumn/column.jelly
+++ b/src/main/resources/jenkins/branch/DescriptionColumn/column.jelly
@@ -4,10 +4,10 @@
     <j:set var="p" value="${col.getPropertyOf(job)}"/>
     <j:choose>
       <j:when test="${p != null and p.objectUrl != null}">
-        <a href="${p.objectUrl}"><j:out value="${col.description(p,job)}"/></a>
+        <a href="${p.objectUrl}"><j:out value="${col.formattedDescription(p,job)}"/></a>
       </j:when>
       <j:otherwise>
-        <j:out value="${col.description(p, job)}"/>
+        <j:out value="${col.formattedDescription(p, job)}"/>
       </j:otherwise>
     </j:choose>
   </td>


### PR DESCRIPTION
This PR adds the support for formating HTML tags in the description column properly.

Before:
![before](https://user-images.githubusercontent.com/11787578/62349583-79d2db00-b500-11e9-9018-7ee2a273cc1d.png)

After:
![after](https://user-images.githubusercontent.com/11787578/62349604-86573380-b500-11e9-932b-284cfeedebf9.png)