### PR TITLE
Why not to expose commit hash from SCM as an environment variable?

### DIFF
--- a/src/main/java/jenkins/branch/BranchNameContributor.java
+++ b/src/main/java/jenkins/branch/BranchNameContributor.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.Date;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.metadata.ContributorMetadataAction;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.mixin.ChangeRequestSCMHead;
@@ -57,10 +58,14 @@ public class BranchNameContributor extends EnvironmentContributor {
             BranchProjectFactory projectFactory = ((MultiBranchProject) parent).getProjectFactory();
             if (projectFactory.isProject(j)) {
                 Branch branch = projectFactory.getBranch(j);
+                SCMRevision rev = projectFactory.getRevision(j);
                 SCMHead head = branch.getHead();
                 // Note: not using Branch.name, since in the future that could be something different
                 // than SCMHead.name, which is what we really want here.
                 envs.put("BRANCH_NAME", head.getName());
+                if (rev != null) {
+                    envs.put("CHANGE_REVISION", rev.toString());
+                }
                 if (head instanceof ChangeRequestSCMHead) {
                     envs.putIfNotNull("CHANGE_ID", ((ChangeRequestSCMHead) head).getId());
                     SCMHead target = ((ChangeRequestSCMHead) head).getTarget();
@@ -83,6 +88,7 @@ public class BranchNameContributor extends EnvironmentContributor {
                         envs.putIfNotNull("CHANGE_AUTHOR_DISPLAY_NAME", cma.getContributorDisplayName());
                         envs.putIfNotNull("CHANGE_AUTHOR_EMAIL", cma.getContributorEmail());
                     }
+
                 }
                 if (head instanceof TagSCMHead) {
                     envs.put("TAG_NAME", head.getName());
@@ -90,6 +96,7 @@ public class BranchNameContributor extends EnvironmentContributor {
                     envs.putIfNotNull("TAG_UNIXTIME", Long.toString(((TagSCMHead) head).getTimestamp()/1000L));
                     envs.putIfNotNull("TAG_DATE", new Date(((TagSCMHead) head).getTimestamp()).toString());
                 }
+
             }
         }
     }

--- a/src/test/java/jenkins/branch/BranchNameContributorTest.java
+++ b/src/test/java/jenkins/branch/BranchNameContributorTest.java
@@ -92,6 +92,7 @@ public class BranchNameContributorTest {
             c.createRepository("foo", MockRepositoryFlags.FORKABLE);
             Integer cr1Num = c.openChangeRequest("foo", "master");
             Integer cr2Num = c.openChangeRequest("foo", "master", MockChangeRequestFlags.FORK);
+            String rev = c.getRevision("foo", "master");
             c.createTag("foo", "master", "v1.0");
             BasicMultiBranchProject prj = r.jenkins.createProject(BasicMultiBranchProject.class, "foo");
             prj.setCriteria(null);
@@ -105,19 +106,25 @@ public class BranchNameContributorTest {
             FreeStyleProject cr2 = prj.getItem("CR-" + cr2Num);
             FreeStyleProject tag = prj.getItem("v1.0");
             assertThat("We now have the master branch", master, notNullValue());
+            assertThat("We now have the revision", rev, notNullValue());
             assertThat("We now have the origin CR branch", cr1, notNullValue());
             assertThat("We now have the form CR branch", cr2, notNullValue());
             assertThat("We now have the tag branch", tag, notNullValue());
             EnvVars env = new EnvVars();
             instance.buildEnvironmentFor(master, env, new LogTaskListener(LOGGER, Level.FINE));
-            assertThat(env.keySet(), contains(is("BRANCH_NAME")));
+            assertThat(env.keySet(), containsInAnyOrder(
+                    is("BRANCH_NAME"),
+                    is("CHANGE_REVISION")
+                    ));
             assertThat(env.get("BRANCH_NAME"), is("master"));
+            assertThat(env.get("CHANGE_REVISION"), is(rev));
 
             env = new EnvVars();
             instance.buildEnvironmentFor(cr1, env, new LogTaskListener(LOGGER, Level.FINE));
             assertThat(env.keySet(), containsInAnyOrder(
                     is("BRANCH_NAME"),
                     is("CHANGE_ID"),
+                    is("CHANGE_REVISION"),
                     is("CHANGE_TARGET"),
                     is("CHANGE_TITLE"),
                     is("CHANGE_URL"),
@@ -142,6 +149,7 @@ public class BranchNameContributorTest {
                     is("BRANCH_NAME"),
                     is("CHANGE_ID"),
                     is("CHANGE_TARGET"),
+                    is("CHANGE_REVISION"),
                     is("CHANGE_TITLE"),
                     is("CHANGE_URL"),
                     is("CHANGE_BRANCH"),


### PR DESCRIPTION
I've started to use GitHub Branch Source plugin for my project. While developing my pipeline I was trying to set PR commit status for which I commit hash was needed. I was wondering if there any way to get it without `checkout` step. It didn't look too impossible - in Multibranch Pipelines and Organization Folders Jenkins "knows" from which commit has Jenkinsfile was taken. I've written the this https://gist.github.com/ababushk//930980d79ab09c74da34be459563f760 and added it to my Global Library. But it looks so "hacky" that I've started to search for a place where other environment variables like `CHANGE_ID` and `BRANCH_NAME` are created. I've found `BranchNameContributor` class to which I've added variable that I desire so much.
I'm completely new in Jenkins plugin development and Java in general, but I'm wondering why such simple thing as commit hash is not available by default.