### PR TITLE
Fix PCT failure on 2.190.x

### DIFF
--- a/src/test/java/jenkins/branch/BuildRetentionBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/BuildRetentionBranchPropertyTest.java
@@ -35,12 +35,17 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import org.junit.ClassRule;
+import org.jvnet.hudson.test.JenkinsRule;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class BuildRetentionBranchPropertyTest {
+
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
 
     @Test
     public void decoratesStandardJobByFieldReflectionAccess() throws Exception {


### PR DESCRIPTION
Caused by https://github.com/jenkinsci/jenkins/pull/4042; https://github.com/jenkinsci/jenkins/pull/4247 would have avoided the need for this, but too late now. [Example](https://ci.jenkins.io/job/Tools/job/bom/job/PR-110/4/testReport/jenkins.branch/BuildRetentionBranchPropertyTest/pct_branch_api_2_190_x___decoratesStandardJobByFieldReflectionAccess/):

```
java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
	at jenkins.model.Jenkins.get(Jenkins.java:772)
	at hudson.model.AbstractProject.<init>(AbstractProject.java:262)
	at hudson.model.Project.<init>(Project.java:92)
	at hudson.model.FreeStyleProject.<init>(FreeStyleProject.java:51)
	at jenkins.branch.BuildRetentionBranchPropertyTest.decoratesStandardJobByFieldReflectionAccess(BuildRetentionBranchPropertyTest.java:48)
```