### PR TITLE
update pom to point to github instead of wiki

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <description>
     This plugin provides an API for multiple branch based projects.
   </description>
-  <url>https://wiki.jenkins.io/display/JENKINS/Branch+API+Plugin</url>
+  <url>https://github.com/jenkinsci/branch-api-plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>


### PR DESCRIPTION
Forgot to  update the pom with  the github url