### PR TITLE
Add new method for performance improvements

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -563,6 +563,19 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     }
 
     /**
+     * Check if there are any visible items in this project
+     * @return true if there are visible items false otherwise
+     */
+    public boolean hasVisibleItems() {
+        for (P item : items.values()) {
+            if (item.hasPermission(Item.READ)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -93,7 +93,7 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
     @NonNull
     @Override
     public synchronized List<View> getViews() {
-        if (owner.getItems().isEmpty()) {
+        if (!owner.hasVisibleItems()) {
             // when there are no branches nor pull requests to show, switch to the special welcome view
             return Collections.singletonList(owner.getWelcomeView());
         }
@@ -123,7 +123,7 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
      */
     @Override
     public synchronized String getPrimaryView() {
-        if (owner.getItems().isEmpty()) {
+        if (!owner.hasVisibleItems()) {
             // when there are no branches nor pull requests to show, switch to the special welcome view
             return BaseEmptyView.VIEW_NAME;
         }


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

Currently just to check if there are no visible items it has to do a permissions check on every item.
This method just adds a quick exit which should improve performance especially considering this method is synchronized.

This method might make more sense in ComputedFolder considering https://github.com/jenkinsci/branch-api-plugin/blob/ad83debf8f48d6ad2661ec2549116b3df8cb0f5b/src/main/java/jenkins/branch/OrganizationFolder.java#L603

But I'd like to start the discussion on this