### PR TITLE
Use new api to reduce checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>6.9</version>
+      <version>6.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <description>
     This plugin provides an API for multiple branch based projects.
   </description>
-  <url>https://wiki.jenkins.io/display/JENKINS/Branch+API+Plugin</url>
+  <url>https://github.com/jenkinsci/branch-api-plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -563,19 +563,6 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     }
 
     /**
-     * Check if there are any visible items in this project
-     * @return true if there are visible items false otherwise
-     */
-    public boolean hasVisibleItems() {
-        for (P item : items.values()) {
-            if (item.hasPermission(Item.READ)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -563,6 +563,19 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     }
 
     /**
+     * Check if there are any visible items in this project
+     * @return true if there are visible items false otherwise
+     */
+    public boolean hasVisibleItems() {
+        for (P item : items.values()) {
+            if (item.hasPermission(Item.READ)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -93,7 +93,7 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
     @NonNull
     @Override
     public synchronized List<View> getViews() {
-        if (owner.getItems().isEmpty()) {
+        if (!owner.hasVisibleItems()) {
             // when there are no branches nor pull requests to show, switch to the special welcome view
             return Collections.singletonList(owner.getWelcomeView());
         }
@@ -123,7 +123,7 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
      */
     @Override
     public synchronized String getPrimaryView() {
-        if (owner.getItems().isEmpty()) {
+        if (!owner.hasVisibleItems()) {
             // when there are no branches nor pull requests to show, switch to the special welcome view
             return BaseEmptyView.VIEW_NAME;
         }


### PR DESCRIPTION
Signed-off-by: Raihaan Shouhell <raihaan.shouhell@autodesk.com>

Re-implementation of #172 

This PR is on the assumption that jenkinsci/cloudbees-folder-plugin#137 gets merged so we can use the new API and potentially reduce the number of calls to `hasPermission`

We see stacktraces such as:
```
java.lang.String$CaseInsensitiveComparator.compare(String.java:1186)
java.lang.String.compareToIgnoreCase(String.java:1239)
hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:40)
hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:34)
jenkins.model.IdStrategy$CaseInsensitive.compare(IdStrategy.java:225)
jenkins.model.IdStrategy.equals(IdStrategy.java:120)
nectar.plugins.rbac.groups.Group.isMatch(Group.java:492)
nectar.plugins.rbac.groups.Group.isMatch(Group.java:445)
nectar.plugins.rbac.groups.Group.isMatch(Group.java:382)
nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:196)
nectar.plugins.rbac.groups.GroupContainerACL._hasPermission(GroupContainerACL.java:123)
nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:76)
jenkins.branch.MultiBranchProject$1.hasPermission(MultiBranchProject.java:786)
hudson.security.ACL.hasPermission(ACL.java:87)
hudson.security.AccessControlled.hasPermission(AccessControlled.java:54)
com.cloudbees.hudson.plugins.folder.AbstractFolder.getItems(AbstractFolder.java:1010)
jenkins.branch.OrganizationFolder.getPrimaryView(OrganizationFolder.java:602)
hudson.model.View.isDefault(View.java:421)
nectar.plugins.rbac.groups.ViewProxyGroupContainer$GroupContainerLocatorImpl.get(ViewProxyGroupContainer.java:250)
nectar.plugins.rbac.groups.GroupContainerLocator.locate(GroupContainerLocator.java:115)
nectar.plugins.rbac.strategy.RoleMatrixAuthorizationStrategyImpl.getACL(RoleMatrixAuthorizationStrategyImpl.java:160)
hudson.model.View.getACL(View.java:602)
jenkins.branch.OrganizationFolderViewHolder$ViewImpl.getACL(OrganizationFolderViewHolder.java:235)
hudson.security.AccessControlled.hasPermission(AccessControlled.java:54)
jenkins.model.NewViewLink$1.hasPermission(NewViewLink.java:51)
jenkins.model.NewViewLink$1.getIconFileName(NewViewLink.java:29)
sun.reflect.GeneratedMethodAccessor591.invoke(Unknown Source)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.apache.commons.jexl.util.PropertyExecutor.execute(PropertyExecutor.java:125)
```
On cloudbees masters and stacktraces such as
```
java.util.HashMap$HashIterator.<init>(HashMap.java:1433)
java.util.HashMap$KeyIterator.<init>(HashMap.java:1467)
java.util.HashMap$KeySet.iterator(HashMap.java:917)
java.util.HashSet.iterator(HashSet.java:173)
org.apache.commons.collections.CollectionUtils.containsAny(CollectionUtils.java:208)
com.michelin.cio.hudson.plugins.rolestrategy.Role.hasAnyPermission(Role.java:169)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$1.perform(RoleMap.java:366)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$RoleWalker.walk(RoleMap.java:445)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$RoleWalker.<init>(RoleMap.java:434)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$1.<init>(RoleMap.java:364)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap.getRolesHavingPermission(RoleMap.java:364)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap.hasPermission(RoleMap.java:105)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap.access$000(RoleMap.java:68)
com.michelin.cio.hudson.plugins.rolestrategy.RoleMap$AclImpl.hasPermission(RoleMap.java:420)
hudson.security.SidACL$1.hasPermission(SidACL.java:144)
hudson.security.SidACL._hasPermission(SidACL.java:80)
hudson.security.SidACL.hasPermission(SidACL.java:52)
org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty$1.hasPermission(BranchJobProperty.java:77)
hudson.security.ACL.hasPermission(ACL.java:87)
hudson.security.AccessControlled.hasPermission(AccessControlled.java:54)
com.cloudbees.hudson.plugins.folder.AbstractFolder.getItems(AbstractFolder.java:1010)
jenkins.branch.MultiBranchProjectViewHolder.getPrimaryView(MultiBranchProjectViewHolder.java:126)
com.cloudbees.hudson.plugins.folder.AbstractFolder$1.primaryView(AbstractFolder.java:266)
hudson.model.ViewGroupMixIn.getPrimaryView(ViewGroupMixIn.java:171)
com.cloudbees.hudson.plugins.folder.AbstractFolder.getPrimaryView(AbstractFolder.java:743)
hudson.model.View.isDefault(View.java:421)
hudson.model.AbstractItem.getUrl(AbstractItem.java:542)
hudson.model.Run.getUrl(Run.java:994)
sun.reflect.GeneratedMethodAccessor354.invoke(Unknown Source)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.apache.commons.jexl.util.PropertyExecutor.execute(PropertyExecutor.java:125)
org.apache.commons.jexl.util.introspection.UberspectImpl$VelGetterImpl.invoke(UberspectImpl.java:314)
org.apache.commons.jexl.parser.ASTArrayAccess.evaluateExpr(ASTArrayAccess.java:185)
org.apache.commons.jexl.parser.ASTIdentifier.execute(ASTIdentifier.java:75)
org.apache.commons.jexl.parser.ASTReference.execute(ASTReference.java:83)
org.apache.commons.jexl.parser.ASTReference.value(ASTReference.java:57)
org.apache.commons.jexl.parser.ASTReferenceExpression.value(ASTReferenceExpression.java:51)
org.apache.commons.jexl.ExpressionImpl.evaluate(ExpressionImpl.java:80)
hudson.ExpressionFactory2$JexlExpression.evaluate(ExpressionFactory2.java:74)
org.apache.commons.jelly.expression.ExpressionSupport.evaluateRecurse(ExpressionSupport.java:61)
org.apache.commons.jelly.expression.ExpressionSupport.evaluateAsString(ExpressionSupport.java:46)
org.apache.commons.jelly.expression.CompositeExpression.evaluateAsString(CompositeExpression.java:256)
org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.buildAttributes(ReallyStaticTagLibrary.java:111)
org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:95)
org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
org.apache.commons.jelly.tags.core.CoreTagLibrary$1.run(CoreTagLibrary.java:98)
org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
```

On our open source masters