### PR TITLE
Reduce scope of locks in MultibranchProjectViewHolder and OrganizationFolderViewHolder

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -75,8 +75,8 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
     /**
      * The primary view name.
      */
-    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "Only need to synchronize initialization")
-    private transient String primaryView = null;
+    @GuardedBy("this")
+    private transient volatile String primaryView = null;
 
     /**
      * Constructor.

--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -74,7 +74,6 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
     /**
      * The primary view name.
      */
-    @GuardedBy("this")
     private transient String primaryView = null;
 
     /**
@@ -97,20 +96,7 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
             // when there are no branches nor pull requests to show, switch to the special welcome view
             return Collections.singletonList(owner.getWelcomeView());
         }
-        if (views == null) {
-            synchronized(this) {
-                if (views == null) {
-                    List<View> views = new ArrayList<>();
-                    for (SCMHeadCategory c : SCMHeadCategory.collectAndSimplify(owner.getSCMSources()).values()) {
-                        views.add(new ViewImpl(owner, c));
-                        if (c.isUncategorized()) {
-                            primaryView = c.getName();
-                        }
-                    }
-                    this.views = views;
-                }
-            }
-        }
+        ensureViews();
         return views;
     }
 
@@ -131,9 +117,7 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
             // when there are no branches nor pull requests to show, switch to the special welcome view
             return BaseEmptyView.VIEW_NAME;
         }
-        if (primaryView == null) {
-            getViews(); // will set primaryView for us
-        }
+        ensureViews();
         return primaryView;
     }
 
@@ -143,6 +127,26 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
     @Override
     public void setPrimaryView(@CheckForNull String name) {
         // ignore
+    }
+
+    /**
+     * Initialize views and primaryView
+     */
+    private void ensureViews() {
+        if (views == null) {
+            synchronized(this) {
+                if (views == null) {
+                    List<View> views = new ArrayList<>();
+                    for (SCMHeadCategory c : SCMHeadCategory.collectAndSimplify(owner.getSCMSources()).values()) {
+                        views.add(new ViewImpl(owner, c));
+                        if (c.isUncategorized()) {
+                            primaryView = c.getName();
+                        }
+                    }
+                    this.views = views;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -27,6 +27,7 @@ package jenkins.branch;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.ListView;
@@ -69,10 +70,12 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
     /**
      * The list of {@link View}s.
      */
+    @GuardedBy("this")
     private transient volatile List<View> views = null;
     /**
      * The primary view name.
      */
+    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "Only need to synchronize initialization")
     private transient String primaryView = null;
 
     /**

--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -69,7 +69,6 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
     /**
      * The list of {@link View}s.
      */
-    @GuardedBy("this")
     private transient volatile List<View> views = null;
     /**
      * The primary view name.

--- a/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
@@ -73,8 +73,8 @@ public class OrganizationFolderViewHolder extends AbstractFolderViewHolder {
     /**
      * The primary view name.
      */
-    @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "Only need to synchronize initialization")
-    private transient String primaryView = null;
+    @GuardedBy("this")
+    private transient volatile String primaryView = null;
 
     /**
      * Constructor.


### PR DESCRIPTION
This PR:
- Reduces scope of locking for better performance
- Refactors code to reduce `hasPermission` calls by half

This was inspired by a stacktrace we often see:
```
"Handling POST /job/git-org/job/git-repo/ajaxExecutors from 10.148.73.74 : qtp2113273959-23348031 View/ajaxExecutors.jelly ExecutorStepExecution/PlaceholderTask/PlaceholderExecutable/executorCell.jelly" prio=5 BLOCKED
	jenkins.branch.MultiBranchProjectViewHolder.getPrimaryView(MultiBranchProjectViewHolder.java:126)
	com.cloudbees.hudson.plugins.folder.AbstractFolder$1.primaryView(AbstractFolder.java:266)
	hudson.model.ViewGroupMixIn.getPrimaryView(ViewGroupMixIn.java:171)
	com.cloudbees.hudson.plugins.folder.AbstractFolder.getPrimaryView(AbstractFolder.java:743)
	hudson.model.View.isDefault(View.java:421)
	hudson.model.AbstractItem.getUrl(AbstractItem.java:542)
	hudson.model.Run.getUrl(Run.java:994)
	org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask.getUrl(ExecutorStepExecution.java:515)
	sun.reflect.GeneratedMethodAccessor488.invoke(Unknown Source)
	sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	java.lang.reflect.Method.invoke(Method.java:498)
```