### PR TITLE
Abort cleanups after multiple failures

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -533,6 +533,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             synchronized (node) {
                 Map<String, String> index = load(workspace);
                 boolean modified = false;
+                int failures = 0;
                 try (ACLContext as = ACL.as(ACL.SYSTEM)) {
                     Iterator<Map.Entry<String, String>> it = index.entrySet().iterator();
                     while (it.hasNext()) {
@@ -551,9 +552,14 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                                     } catch (IOException x) {
                                         LOGGER.log(Level.WARNING, "could not delete workspace " + child, x);
                                         listener.getLogger().println("could not delete workspace " + child + " , wrong file ownership? Review exception in jenkins log and manually remove the directory");
+                                        failures++;
                                     }
                                 }
                             }
+                        }
+                        if (failures >= 3) {
+                            LOGGER.warning("Multiple failures when cleaning up workspaces on " + node.getDisplayName() + " aborting cleanup...");
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
In cases where multiple workspaces have deletion issues. this causes a large mounts of logspam on the master such as:

```
could not delete workspace /path/to/folder
jenkins.util.io.CompositeIOException: Unable to delete '/path/to/folder'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts.
	at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:95)
	at hudson.Util.deleteRecursive(Util.java:293)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1272)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1268)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3050)
	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: hudson.remoting.Channel$CallSiteStackTrace: Remote call to AGENT-NAME
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1743)
		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:357)
		at hudson.remoting.Channel.call(Channel.java:957)
		at hudson.FilePath.act(FilePath.java:1070)
		at hudson.FilePath.act(FilePath.java:1059)
		at hudson.FilePath.deleteRecursive(FilePath.java:1266)
		at jenkins.branch.WorkspaceLocatorImpl$Collector.onOnline(WorkspaceLocatorImpl.java:544)
		at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:698)
		at hudson.slaves.SlaveComputer.setChannel(SlaveComputer.java:432)
		at hudson.plugins.sshslaves.SSHLauncher.startAgent(SSHLauncher.java:607)
		at hudson.plugins.sshslaves.SSHLauncher.access$400(SSHLauncher.java:113)
		at hudson.plugins.sshslaves.SSHLauncher$1.call(SSHLauncher.java:441)
		at hudson.plugins.sshslaves.SSHLauncher$1.call(SSHLauncher.java:406)
		... 4 more
java.nio.file.FileSystemException: /path/to/folder/file: Operation not permitted
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:91)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileAttributeViews$Posix.setMode(UnixFileAttributeViews.java:238)
	at sun.nio.fs.UnixFileAttributeViews$Posix.setPermissions(UnixFileAttributeViews.java:260)
	at java.nio.file.Files.setPosixFilePermissions(Files.java:2045)
	at jenkins.util.io.PathRemover.makeWritable(PathRemover.java:282)
	at jenkins.util.io.PathRemover.makeRemovable(PathRemover.java:255)
	at jenkins.util.io.PathRemover.removeOrMakeRemovableThenRemove(PathRemover.java:235)
	at jenkins.util.io.PathRemover.tryRemoveFile(PathRemover.java:201)
	at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:212)
	at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:222)
	at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:211)
	at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:222)
	at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:211)
	at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:222)
	at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:211)
	at jenkins.util.io.PathRemover.tryRemoveDirectoryContents(PathRemover.java:222)
	at jenkins.util.io.PathRemover.tryRemoveRecursive(PathRemover.java:211)
	at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:92)
	at hudson.Util.deleteRecursive(Util.java:293)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1272)
	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1268)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3050)
	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
Inform the user and abort the cleanup to protect the master from performance issues due to the logspam.

We have had our master unable to be reached via browser due to every node having deletion issues.