### PR TITLE
Cleanup tests

### DIFF
--- a/src/test/java/jenkins/branch/BranchNameContributorTest.java
+++ b/src/test/java/jenkins/branch/BranchNameContributorTest.java
@@ -25,9 +25,7 @@
 package jenkins.branch;
 
 import hudson.EnvVars;
-import hudson.model.Computer;
 import hudson.model.EnvironmentContributor;
-import hudson.model.Executor;
 import hudson.model.FreeStyleProject;
 import hudson.model.TopLevelItem;
 import hudson.util.LogTaskListener;
@@ -68,18 +66,6 @@ public class BranchNameContributorTest {
     public void cleanOutAllItems() throws Exception {
         for (TopLevelItem i : r.getInstance().getItems()) {
             i.delete();
-        }
-        for (Computer comp : r.jenkins.getComputers()) {
-            for (Executor e : comp.getExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
-            for (Executor e : comp.getOneOffExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
         }
     }
 

--- a/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
@@ -59,7 +59,7 @@ public class NoTriggerBranchPropertyTest {
         sampleRepo.git("add", "server");
         sampleRepo.git("commit", "--all", "--message=release");
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
-        BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
+        BranchSource branchSource = new BranchSource(new GitSCMSource(sampleRepo.toString()));
         branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
             new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
         }));

--- a/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
@@ -33,8 +33,13 @@ import hudson.model.queue.QueueTaskFuture;
 import jenkins.branch.harness.MultiBranchImpl;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
+
+import java.util.Collections;
+
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -59,7 +64,9 @@ public class NoTriggerBranchPropertyTest {
         sampleRepo.git("add", "server");
         sampleRepo.git("commit", "--all", "--message=release");
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
-        BranchSource branchSource = new BranchSource(new GitSCMSource(sampleRepo.toString()));
+        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+        source.setTraits(Collections.singletonList(new BranchDiscoveryTrait()));
+        BranchSource branchSource = new BranchSource(source);
         branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
             new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
         }));

--- a/src/test/java/jenkins/branch/NoTriggerOrganizationFolderPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerOrganizationFolderPropertyTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import jenkins.branch.harness.MultiBranchImpl;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.impl.SingleSCMNavigator;
 import static org.junit.Assert.assertEquals;
@@ -67,7 +68,9 @@ public class NoTriggerOrganizationFolderPropertyTest {
         assertEquals(".*", prop.getBranches());
         top.getProperties().replace(new NoTriggerOrganizationFolderProperty("(?!release.*).*"));
         top.getProjectFactories().add(new OrganizationFolderTest.MockFactory());
-        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(sampleRepo.toString()))));
+        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+        source.setTraits(Collections.singletonList(new BranchDiscoveryTrait()));
+        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.singletonList(source)));
         r.configRoundtrip(top);
         prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
         assertNotNull(prop);

--- a/src/test/java/jenkins/branch/NoTriggerOrganizationFolderPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerOrganizationFolderPropertyTest.java
@@ -67,7 +67,7 @@ public class NoTriggerOrganizationFolderPropertyTest {
         assertEquals(".*", prop.getBranches());
         top.getProperties().replace(new NoTriggerOrganizationFolderProperty("(?!release.*).*"));
         top.getProjectFactories().add(new OrganizationFolderTest.MockFactory());
-        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false))));
+        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(sampleRepo.toString()))));
         r.configRoundtrip(top);
         prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
         assertNotNull(prop);

--- a/src/test/java/jenkins/branch/OrganizationChildHealthMetricsPropertyTest.java
+++ b/src/test/java/jenkins/branch/OrganizationChildHealthMetricsPropertyTest.java
@@ -26,8 +26,6 @@ package jenkins.branch;
 
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetric;
 import com.cloudbees.hudson.plugins.folder.health.FolderHealthMetricDescriptor;
-import hudson.model.Computer;
-import hudson.model.Executor;
 import hudson.model.TopLevelItem;
 import hudson.util.DescribableList;
 import integration.harness.BasicMultiBranchProject;
@@ -65,18 +63,6 @@ public class OrganizationChildHealthMetricsPropertyTest {
     public void cleanOutAllItems() throws Exception {
         for (TopLevelItem i : r.getInstance().getItems()) {
             i.delete();
-        }
-        for (Computer comp : r.jenkins.getComputers()) {
-            for (Executor e : comp.getExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
-            for (Executor e : comp.getOneOffExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
         }
     }
 

--- a/src/test/java/jenkins/branch/OrganizationChildOrphanedItemsPropertyTest.java
+++ b/src/test/java/jenkins/branch/OrganizationChildOrphanedItemsPropertyTest.java
@@ -62,18 +62,6 @@ public class OrganizationChildOrphanedItemsPropertyTest {
         for (TopLevelItem i : r.getInstance().getItems()) {
             i.delete();
         }
-        for (Computer comp : r.jenkins.getComputers()) {
-            for (Executor e : comp.getExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
-            for (Executor e : comp.getOneOffExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
-        }
     }
 
     @Test

--- a/src/test/java/jenkins/branch/OrganizationChildTriggersPropertyTest.java
+++ b/src/test/java/jenkins/branch/OrganizationChildTriggersPropertyTest.java
@@ -68,18 +68,6 @@ public class OrganizationChildTriggersPropertyTest {
         for (TopLevelItem i : r.getInstance().getItems()) {
             i.delete();
         }
-        for (Computer comp : r.jenkins.getComputers()) {
-            for (Executor e : comp.getExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
-            for (Executor e : comp.getOneOffExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
-        }
     }
 
     @Test

--- a/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
+++ b/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
@@ -62,7 +62,7 @@ public class OverrideIndexTriggersJobPropertyTest {
         sampleRepo.git("add", "server");
         sampleRepo.git("commit", "--all", "--message=release");
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
-        BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
+        BranchSource branchSource = new BranchSource(new GitSCMSource(sampleRepo.toString()));
         branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
             new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
         }));
@@ -128,7 +128,7 @@ public class OverrideIndexTriggersJobPropertyTest {
         assertEquals(".*", prop.getBranches());
         top.getProperties().replace(new NoTriggerOrganizationFolderProperty("(?!release.*).*"));
         top.getProjectFactories().add(new OrganizationFolderTest.MockFactory());
-        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false))));
+        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(sampleRepo.toString()))));
         r.configRoundtrip(top);
         prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
         assertNotNull(prop);
@@ -188,7 +188,7 @@ public class OverrideIndexTriggersJobPropertyTest {
         sampleRepo.git("add", "stuff");
         sampleRepo.git("commit", "--all", "--message=master-1");
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
-        BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
+        BranchSource branchSource = new BranchSource(new GitSCMSource(sampleRepo.toString()));
         stuff.getSourcesList().add(branchSource);
         r.configRoundtrip(stuff);
         stuff.scheduleBuild2(0).getFuture().get();

--- a/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
+++ b/src/test/java/jenkins/branch/OverrideIndexTriggersJobPropertyTest.java
@@ -32,6 +32,7 @@ import static jenkins.branch.NoTriggerBranchPropertyTest.showComputation;
 import jenkins.branch.harness.MultiBranchImpl;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.impl.SingleSCMNavigator;
 import static org.junit.Assert.assertEquals;
@@ -62,7 +63,9 @@ public class OverrideIndexTriggersJobPropertyTest {
         sampleRepo.git("add", "server");
         sampleRepo.git("commit", "--all", "--message=release");
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
-        BranchSource branchSource = new BranchSource(new GitSCMSource(sampleRepo.toString()));
+        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+        source.setTraits(Collections.singletonList(new BranchDiscoveryTrait()));
+        BranchSource branchSource = new BranchSource(source);
         branchSource.setStrategy(new NamedExceptionsBranchPropertyStrategy(new BranchProperty[0], new NamedExceptionsBranchPropertyStrategy.Named[] {
             new NamedExceptionsBranchPropertyStrategy.Named("release*", new BranchProperty[] {new NoTriggerBranchProperty()})
         }));
@@ -128,7 +131,9 @@ public class OverrideIndexTriggersJobPropertyTest {
         assertEquals(".*", prop.getBranches());
         top.getProperties().replace(new NoTriggerOrganizationFolderProperty("(?!release.*).*"));
         top.getProjectFactories().add(new OrganizationFolderTest.MockFactory());
-        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.<SCMSource>singletonList(new GitSCMSource(sampleRepo.toString()))));
+        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+        source.setTraits(Collections.singletonList(new BranchDiscoveryTrait()));
+        top.getNavigators().add(new SingleSCMNavigator("stuff", Collections.singletonList(source)));
         r.configRoundtrip(top);
         prop = top.getProperties().get(NoTriggerOrganizationFolderProperty.class);
         assertNotNull(prop);
@@ -188,7 +193,9 @@ public class OverrideIndexTriggersJobPropertyTest {
         sampleRepo.git("add", "stuff");
         sampleRepo.git("commit", "--all", "--message=master-1");
         MultiBranchImpl stuff = r.jenkins.createProject(MultiBranchImpl.class, "stuff");
-        BranchSource branchSource = new BranchSource(new GitSCMSource(sampleRepo.toString()));
+        GitSCMSource source = new GitSCMSource(sampleRepo.toString());
+        source.setTraits(Collections.singletonList(new BranchDiscoveryTrait()));
+        BranchSource branchSource = new BranchSource(source);
         stuff.getSourcesList().add(branchSource);
         r.configRoundtrip(stuff);
         stuff.scheduleBuild2(0).getFuture().get();

--- a/src/test/java/jenkins/branch/PrimaryBranchHealthMetricTest.java
+++ b/src/test/java/jenkins/branch/PrimaryBranchHealthMetricTest.java
@@ -1,7 +1,5 @@
 package jenkins.branch;
 
-import hudson.model.Computer;
-import hudson.model.Executor;
 import hudson.model.FreeStyleProject;
 import hudson.model.TopLevelItem;
 import integration.harness.BasicMultiBranchProject;
@@ -29,18 +27,6 @@ public class PrimaryBranchHealthMetricTest {
     public void cleanOutAllItems() throws Exception {
         for (TopLevelItem i : r.getInstance().getItems()) {
             i.delete();
-        }
-        for (Computer comp : r.jenkins.getComputers()) {
-            for (Executor e : comp.getExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
-            for (Executor e : comp.getOneOffExecutors()) {
-                if (e.getCauseOfDeath() != null) {
-                    e.doYank();
-                }
-            }
         }
     }
 

--- a/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
@@ -197,11 +197,12 @@ public class RateLimitBranchPropertyTest {
             assertThat(startCondition.isDone(), is(true));
             // it can take more than the requested delay... that's ok, but it should not be
             // more than 500ms longer (i.e. 5 of our Queue.maintain loops above)
+            final long delay = (long)(60.f * 60.f / rate * 1000);
             assertThat("At least the rate implied delay but no more than 500ms longer",
                     System.currentTimeMillis() - startTime,
                     allOf(
-                            greaterThanOrEqualTo(60 * 60 / rate * 1000L - 200L),
-                            lessThanOrEqualTo(60 * 60 / rate * 1000L * 500L)
+                            greaterThanOrEqualTo(delay - 200L),
+                            lessThanOrEqualTo(delay + 500L)
                     )
             );
             future.get();
@@ -277,7 +278,7 @@ public class RateLimitBranchPropertyTest {
             // will pick up more responsively than the default 5s
             startCondition = future2.getStartCondition();
             long endTime = startTime + 60*60/rate*1000L*5; // at least 5 times the expected delay
-            while (!startCondition.isDone() && System.currentTimeMillis() < midTime) {
+            while (!startCondition.isDone() && System.currentTimeMillis() < endTime) {
                 Queue.getInstance().maintain();
                 Thread.sleep(100);
             }
@@ -286,11 +287,12 @@ public class RateLimitBranchPropertyTest {
             FreeStyleBuild secondBuild = startCondition.get();
             // it can take more than the requested delay... that's ok, but it should not be
             // more than 500ms longer (i.e. 5 of our Queue.maintain loops above)
+            final long delay = (long)(60.f * 60.f / rate * 1000);
             assertThat("At least the rate implied delay but no more than 500ms longer",
                     secondBuild.getStartTimeInMillis() - firstBuild.getStartTimeInMillis(),
                     allOf(
-                            greaterThanOrEqualTo(60 * 60 / rate * 1000L - 200L),
-                            lessThanOrEqualTo(60 * 60 / rate * 1000L * 500L)
+                            greaterThanOrEqualTo(delay - 200L),
+                            lessThanOrEqualTo(delay + 500L)
                     )
             );
             future.get();

--- a/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
@@ -65,10 +65,10 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.isNotNull;
 
 public class RateLimitBranchPropertyTest {
     /**
@@ -170,7 +170,7 @@ public class RateLimitBranchPropertyTest {
             );
             assertThat(master.isInQueue(), is(false));
             assertThat(master.getQueueItem(), nullValue());
-            assertThat(master.getBuilds().getLastBuild(), isNotNull());
+            assertThat(master.getBuilds().getLastBuild(), notNullValue());
             long startTime = master.getBuilds().getLastBuild().getTimeInMillis();
             QueueTaskFuture<FreeStyleBuild> future = master.scheduleBuild2(0);
 

--- a/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
@@ -68,6 +68,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.isNotNull;
 
 public class RateLimitBranchPropertyTest {
     /**
@@ -169,13 +170,14 @@ public class RateLimitBranchPropertyTest {
             );
             assertThat(master.isInQueue(), is(false));
             assertThat(master.getQueueItem(), nullValue());
+            assertThat(master.getBuilds().getLastBuild(), isNotNull());
+            long startTime = master.getBuilds().getLastBuild().getTimeInMillis();
             QueueTaskFuture<FreeStyleBuild> future = master.scheduleBuild2(0);
 
             // let the item get added to the queue
             while (!master.isInQueue()) {
                 Thread.yield();
             }
-            long startTime = System.currentTimeMillis();
             assertThat(master.isInQueue(), is(true));
 
             // while it is in the queue, until queue maintenance takes place, it will not be flagged as blocked
@@ -218,7 +220,7 @@ public class RateLimitBranchPropertyTest {
             prj.setCriteria(null);
             BranchSource source = new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches()));
             BasicParameterDefinitionBranchProperty p = new BasicParameterDefinitionBranchProperty();
-            p.setParameterDefinitions(Collections.<ParameterDefinition>singletonList(new StringParameterDefinition("FOO", "BAR")));
+            p.setParameterDefinitions(Collections.singletonList(new StringParameterDefinition("FOO", "BAR")));
             source.setStrategy(new DefaultBranchPropertyStrategy(new BranchProperty[]{
                     new RateLimitBranchProperty(rate, "hour", false),
                     new ConcurrentBuildBranchProperty(),
@@ -245,7 +247,7 @@ public class RateLimitBranchPropertyTest {
             QueueTaskFuture<FreeStyleBuild> future = master.scheduleBuild2(0);
             QueueTaskFuture<FreeStyleBuild> future2 = master.scheduleBuild2(0, (Cause) null,
                     (Action) new ParametersAction(
-                            Collections.<ParameterValue>singletonList(new StringParameterValue("FOO", "MANCHU"))));
+                            Collections.singletonList(new StringParameterValue("FOO", "MANCHU"))));
             assertThat(future, not(is(future2)));
 
             // let the item get added to the queue
@@ -308,7 +310,7 @@ public class RateLimitBranchPropertyTest {
             prj.setCriteria(null);
             BranchSource source = new BranchSource(new MockSCMSource(c, "foo", new MockSCMDiscoverBranches()));
             BasicParameterDefinitionBranchProperty p = new BasicParameterDefinitionBranchProperty();
-            p.setParameterDefinitions(Collections.<ParameterDefinition>singletonList(new StringParameterDefinition("FOO", "BAR")));
+            p.setParameterDefinitions(Collections.singletonList(new StringParameterDefinition("FOO", "BAR")));
             source.setStrategy(new DefaultBranchPropertyStrategy(new BranchProperty[]{
                     new RateLimitBranchProperty(1, "hour", true),
                     p
@@ -380,7 +382,7 @@ public class RateLimitBranchPropertyTest {
             // now we trigger a user build... it should skip the queue
             QueueTaskFuture<FreeStyleBuild> future2 = master.scheduleBuild2(0, new Cause.UserIdCause(),
                     (Action) new ParametersAction(
-                            Collections.<ParameterValue>singletonList(new StringParameterValue("FOO", "MANCHU"))));
+                            Collections.singletonList(new StringParameterValue("FOO", "MANCHU"))));
             // now we wait for the start... invoking queue maintain every 100ms so that the queue
             // will pick up more responsively than the default 5s
             LOGGER.info("Checking user submitted build skips");


### PR DESCRIPTION
- Cleanup some tests with using the older now NOOPed `doYank()` method
- Rewrite the delay calculation in RateLimitBranchPropertyTest to not be truncated.
- Fix the delay to not be an overly bloated number

Running it in CI to try to reproduce all the test flakes