### PR TITLE
[JENKINS-61438] Demonstration of IAE from Stapler

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 buildPlugin(configurations: [
         [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "linux", jdk: "11", jenkins: "2.249" ],
         [ platform: "windows", jdk: "8", jenkins: "2.235.3", javaLevel: "8" ],
         [ platform: "linux", jdk: "11", jenkins: "2.235.3", javaLevel: "8" ]
     ])

--- a/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
@@ -121,8 +121,7 @@ public class ParameterDefinitionBranchPropertyTest {
     }
 
     @Issue("JENKINS-61438")
-    // TODO Enable this test case when jenkins.version includes the patch in stapler/stapler#182 
-    @Ignore("Enable this test when stapler/stapler#182 is merged and the jenkins.version will include the patch")
+    @Ignore("TODO enable in 2.242+")
     @Test
     public void choiceParameterIssue() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {

--- a/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
@@ -25,25 +25,6 @@
 
 package jenkins.branch;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-
-import java.util.Collections;
-
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.TestExtension;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.ChoiceParameterDefinition;
 import hudson.model.ItemGroup;
@@ -53,10 +34,29 @@ import hudson.model.StringParameterDefinition;
 import hudson.model.TopLevelItem;
 import integration.harness.BasicDummyStepBranchProperty;
 import integration.harness.BasicMultiBranchProject;
+import java.util.Arrays;
+import java.util.Collections;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
 import jenkins.scm.impl.mock.MockSCMSource;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 public class ParameterDefinitionBranchPropertyTest {
     /**
@@ -121,6 +121,8 @@ public class ParameterDefinitionBranchPropertyTest {
     }
 
     @Issue("JENKINS-61438")
+    // TODO Enable this test case when jenkins.version includes the patch in stapler/stapler#182 
+    @Ignore("Enable this test when stapler/stapler#182 is merged and the jenkins.version will include the patch")
     @Test
     public void choiceParameterIssue() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
@@ -146,7 +148,7 @@ public class ParameterDefinitionBranchPropertyTest {
                     allOf(
                             instanceOf(ChoiceParameterDefinition.class),
                             hasProperty("name", is("CHOOSE")),
-                            hasProperty("defaultValue", is(new String[] { "a", "b" })),
+                            hasProperty("choices", is(Arrays.asList("a", "b"))),
                             hasProperty("description", is("choose one"))
                             )
                     ));

--- a/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/ParameterDefinitionBranchPropertyTest.java
@@ -32,10 +32,13 @@ import hudson.model.Job;
 import hudson.model.ParameterDefinition;
 import hudson.model.StringParameterDefinition;
 import hudson.model.TopLevelItem;
+import hudson.util.VersionNumber;
 import integration.harness.BasicDummyStepBranchProperty;
 import integration.harness.BasicMultiBranchProject;
 import java.util.Arrays;
 import java.util.Collections;
+
+import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
@@ -50,13 +53,8 @@ import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assume.assumeThat;
 
 public class ParameterDefinitionBranchPropertyTest {
     /**
@@ -121,9 +119,9 @@ public class ParameterDefinitionBranchPropertyTest {
     }
 
     @Issue("JENKINS-61438")
-    @Ignore("TODO enable in 2.242+")
     @Test
     public void choiceParameterIssue() throws Exception {
+        assumeThat(Jenkins.getVersion(), greaterThanOrEqualTo(new VersionNumber("2.242")));
         try (MockSCMController c = MockSCMController.create()) {
             c.createRepository("foo");
             BasicMultiBranchProject prj = r.jenkins.createProject(BasicMultiBranchProject.class, "foo");


### PR DESCRIPTION
The new test case fails with
```
java.lang.IllegalArgumentException: Unable to convert to class java.lang.Object
	at org.kohsuke.stapler.RequestImpl$TypePair.convertJSON(RequestImpl.java:738)
	at org.kohsuke.stapler.RequestImpl.bindJSON(RequestImpl.java:478)
	at org.kohsuke.stapler.RequestImpl.injectSetters(RequestImpl.java:834)
	at org.kohsuke.stapler.RequestImpl.instantiate(RequestImpl.java:784)
	at org.kohsuke.stapler.RequestImpl.access$200(RequestImpl.java:83)
	at org.kohsuke.stapler.RequestImpl$TypePair.convertJSON(RequestImpl.java:678)
Caused: java.lang.IllegalArgumentException: Failed to instantiate class hudson.model.ParameterDefinition from {"name":"CHOOSE","choices":"a\nb","description":"choose one","stapler-class":"hudson.model.ChoiceParameterDefinition","$class":"hudson.model.ChoiceParameterDefinition"}
	at org.kohsuke.stapler.RequestImpl$TypePair.convertJSON(RequestImpl.java:681)
```

@jglick Now I will try to use the incremental build of stapler to prove the fix is valid