### PR TITLE
WorkspaceLocatorImpl should not use Node instances as monitors

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -119,7 +119,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
      * File containing pairs of lines tracking workspaces.
      * The first line in a pair is a {@link TopLevelItem#getFullName};
      * the second is a workspace-relative path.
-     * Reads and writes to this file should be synchronized on the {@link Node}.
+     * Reads and writes to this file should be synchronized on {@link #lockFor}.
      */
     static final String INDEX_FILE_NAME = "workspaces.txt";
 
@@ -315,7 +315,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         public Object load(Node node) throws Exception {
             // Avoiding new Object() to prepare for http://cr.openjdk.java.net/~briangoetz/valhalla/sov/02-object-model.html
             // Avoiding new String(…) because static analyzers complain
-            // Could use anything but hoping that a future JVM enhanced thread dumps to display monitors of type String
+            // Could use anything but hoping that a future JVM enhances thread dumps to display monitors of type String
             return new StringBuilder("WorkspaceLocatorImpl lock for ").append(node.getNodeName()).toString();
         }
     });


### PR DESCRIPTION
Looking at a thread dump from CloudBees Core (not that it likely matters) like

```
Handling GET /…/ from … View/index.jelly View/sidepanel.jelly
java.lang.Thread.State: BLOCKED (on object monitor)
	at com.cloudbees.opscenter.client.cloud.StandardCloudSlave.getNodeUsage(StandardCloudSlave.java:312)
	- waiting to lock <0x…> (a com.cloudbees.opscenter.client.cloud.StandardCloudSlave)
	at com.cloudbees.opscenter.client.cloud.StandardCloudSlave.getNumExecutors(StandardCloudSlave.java:381)
	at com.cloudbees.opscenter.client.cloud.OperationsCenterCloudComputer.isAcceptingTasks(OperationsCenterCloudComputer.java:71)
	at hudson.model.Computer.getIconClassName(Computer.java:753)
"Executor #0 for … : executing PlaceholderExecutable:ExecutorStepExecution.PlaceholderTask{…}" …
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at hudson.remoting.FastPipedInputStream.read(FastPipedInputStream.java:175)
	- locked <0x…> (a [B)
	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	- locked <0x…> (a java.io.InputStreamReader)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.BufferedReader.fill(BufferedReader.java:161)
	at java.io.BufferedReader.readLine(BufferedReader.java:324)
	- locked <0x…> (a java.io.InputStreamReader)
	at java.io.BufferedReader.readLine(BufferedReader.java:389)
	at jenkins.branch.WorkspaceLocatorImpl.load(WorkspaceLocatorImpl.java:222)
	at jenkins.branch.WorkspaceLocatorImpl.locate(WorkspaceLocatorImpl.java:159)
	- locked <0x…> (a com.cloudbees.opscenter.client.cloud.StandardCloudSlave)
	at jenkins.branch.WorkspaceLocatorImpl.locate(WorkspaceLocatorImpl.java:129)
	at jenkins.branch.WorkspaceLocatorImpl.locate(WorkspaceLocatorImpl.java:125)
	at hudson.model.Slave.getWorkspaceFor(Slave.java:340)
	at org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask$PlaceholderExecutable.run(ExecutorStepExecution.java:827)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:427)
```

Setting aside why the agent was unresponsive to small Remoting requests, we should not be blocking like this.

Note that we are acquiring the lock _prior_ to potentially benefitting from the caching introduced in #188.