### PR TITLE
Fix mockito issues with JDK11 and jenkins 2.222.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>3.56</version>
     <relativePath />
   </parent>
 
@@ -67,10 +67,9 @@
   <properties>
     <revision>2.5.7</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
-    <scm-api.version>2.4.1</scm-api.version>
-    <git-plugin.version>3.10.0</git-plugin.version>
+    <jenkins.version>2.176.4</jenkins.version>
+    <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
 
   <repositories>
@@ -87,36 +86,38 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.176.x</artifactId>
+        <version>9</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>${scm-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>6.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.18</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.8.5</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency> <!-- previously gathered from org.jenkins-ci.lib:lib-jenkins-maven-embedder -->
       <groupId>org.codehaus.plexus</groupId>
@@ -127,20 +128,17 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>${scm-api.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.16</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>${git-plugin.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -156,14 +154,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>${git-plugin.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/jenkins/branch/BranchCategoryFilterTest.java
+++ b/src/test/java/jenkins/branch/BranchCategoryFilterTest.java
@@ -29,16 +29,26 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
+import hudson.model.TopLevelItemDescriptor;
 import hudson.model.View;
 import hudson.scm.SCM;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.SortedMap;
+
 import javax.annotation.Nonnull;
+
+import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.SCMSourceDescriptor;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.TagSCMHeadCategory;
@@ -49,7 +59,6 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,28 +70,25 @@ public class BranchCategoryFilterTest {
         when(filteringView.getOwner()).thenReturn(owner);
         BranchProjectFactory factory = mock(BranchProjectFactory.class);
         when(owner.getProjectFactory()).thenReturn(factory);
-        MockSCMSource source = mock(MockSCMSource.class);
-        SCMSourceDescriptor sourceDescriptor = new MockSCMSource.MockSCMSourceDescriptor();
+        MockSCMSource source = new MockSCMSource();
         when(owner.getSCMSources()).thenReturn(Collections.singletonList(source));
-        when(source.getDescriptor()).thenReturn(sourceDescriptor);
-        when(source.isCategoryEnabled(any(SCMHeadCategory.class))).thenReturn(true);
-        TopLevelJob child1 = mock(TopLevelJob.class);
+        TopLevelJob child1 = new TopLevelJob("child1");
         when(factory.isProject(child1)).thenReturn(true);
         when(factory.asProject(child1)).thenReturn(child1);
         SCM scm = mock(SCM.class);
         when(factory.getBranch(child1)).thenReturn(
                 new Branch("1", new MockSCMHead("master"), scm, Collections.<BranchProperty>emptyList()));
-        TopLevelJob child2 = mock(TopLevelJob.class);
+        TopLevelJob child2 = new TopLevelJob("child2");
         when(factory.isProject(child2)).thenReturn(true);
         when(factory.asProject(child2)).thenReturn(child2);
         when(factory.getBranch(child2)).thenReturn(new Branch("1", new MockSCMHead("fork"), scm,
                 Collections.<BranchProperty>emptyList()));
-        TopLevelJob child3 = mock(TopLevelJob.class);
+        TopLevelJob child3 = new TopLevelJob("child3");
         when(factory.isProject(child3)).thenReturn(true);
         when(factory.asProject(child3)).thenReturn(child3);
         when(factory.getBranch(child3)).thenReturn(new Branch("1", new MockTagSCMHead("master-1.0", 0L), scm,
                 Collections.<BranchProperty>emptyList()));
-        TopLevelJob child4 = mock(TopLevelJob.class);
+        TopLevelJob child4 = new TopLevelJob("child4");
         when(factory.isProject(child4)).thenReturn(false);
         List<TopLevelItem> added = new ArrayList<>();
         added.add(child1);
@@ -112,28 +118,25 @@ public class BranchCategoryFilterTest {
         when(filteringView.getOwner()).thenReturn(owner);
         BranchProjectFactory factory = mock(BranchProjectFactory.class);
         when(owner.getProjectFactory()).thenReturn(factory);
-        MockSCMSource source = mock(MockSCMSource.class);
-        SCMSourceDescriptor sourceDescriptor = new MockSCMSource.MockSCMSourceDescriptor();
+        MockSCMSource source = new MockSCMSource();
         when(owner.getSCMSources()).thenReturn(Collections.singletonList(source));
-        when(source.getDescriptor()).thenReturn(sourceDescriptor);
-        when(source.isCategoryEnabled(any(SCMHeadCategory.class))).thenReturn(true);
-        TopLevelJob child1 = mock(TopLevelJob.class);
+        TopLevelJob child1 = new TopLevelJob("child1");
         when(factory.isProject(child1)).thenReturn(true);
         when(factory.asProject(child1)).thenReturn(child1);
         SCM scm = mock(SCM.class);
         when(factory.getBranch(child1)).thenReturn(
                 new Branch("1", new MockSCMHead("master"), scm, Collections.<BranchProperty>emptyList()));
-        TopLevelJob child2 = mock(TopLevelJob.class);
+        TopLevelJob child2 = new TopLevelJob("child2");
         when(factory.isProject(child2)).thenReturn(true);
         when(factory.asProject(child2)).thenReturn(child2);
         when(factory.getBranch(child2)).thenReturn(new Branch("1", new MockSCMHead("fork"), scm,
                 Collections.<BranchProperty>emptyList()));
-        TopLevelJob child3 = mock(TopLevelJob.class);
+        TopLevelJob child3 = new TopLevelJob("child3");
         when(factory.isProject(child3)).thenReturn(true);
         when(factory.asProject(child3)).thenReturn(child3);
         when(factory.getBranch(child3)).thenReturn(new Branch("1", new MockTagSCMHead("master-1.0", 0L), scm,
                 Collections.<BranchProperty>emptyList()));
-        TopLevelJob child4 = mock(TopLevelJob.class);
+        TopLevelJob child4 = new TopLevelJob("child4");
         when(factory.isProject(child4)).thenReturn(false);
         List<TopLevelItem> added = new ArrayList<>();
         added.add(child1);
@@ -147,10 +150,29 @@ public class BranchCategoryFilterTest {
 
     }
 
-    private static abstract class TopLevelJob extends Job<TopLevelJob, TopLevelRun> implements TopLevelItem {
+    private static class TopLevelJob extends Job<TopLevelJob, TopLevelRun> implements TopLevelItem {
 
-        protected TopLevelJob(ItemGroup parent, String name) {
-            super(parent, name);
+        protected TopLevelJob(String name) {
+            super(null, name);
+        }
+
+        @Override
+        public TopLevelItemDescriptor getDescriptor() {
+            return null;
+        }
+
+        @Override
+        public boolean isBuildable() {
+            return false;
+        }
+
+        @Override
+        protected SortedMap<Integer, ? extends TopLevelRun> _getRuns() {
+            return null;
+        }
+
+        @Override
+        protected void removeRun(TopLevelRun run) {
         }
     }
 
@@ -161,15 +183,23 @@ public class BranchCategoryFilterTest {
         }
     }
 
-    private static abstract class MockSCMSource extends SCMSource {
+    private static class MockSCMSource extends SCMSource {
+
+        private MockSCMSourceDescriptor descriptor;
 
         protected MockSCMSource() {
             super("1");
+            this.descriptor = new MockSCMSourceDescriptor();
         }
 
         @Override
         public boolean isCategoryEnabled(@NonNull SCMHeadCategory category) {
             return true;
+        }
+
+        @Override
+        public SCMSourceDescriptor getDescriptor() {
+            return descriptor;
         }
 
         private static class MockSCMSourceDescriptor extends SCMSourceDescriptor {
@@ -183,6 +213,18 @@ public class BranchCategoryFilterTest {
                         ChangeRequestSCMHeadCategory.DEFAULT
                 };
             }
+        }
+
+        @Override
+        protected void retrieve(SCMSourceCriteria criteria,
+                                SCMHeadObserver observer,
+                                SCMHeadEvent<?> event,
+                                TaskListener listener) throws IOException, InterruptedException {
+        }
+
+        @Override
+        public SCM build(SCMHead head, SCMRevision revision) {
+            return null;
         }
 
     }


### PR DESCRIPTION
This PR will fix the issue of test cases in master when run on JDK11
The solution was remove mockito from this class so that now master can use the mockito version defined in the parent pom.

@dwnusbaum the issue is regardless the version of mockito. If run individually the test pass. If you run all together something play with cache of mockito/bytebuddy that causes the constructor not be visible.
