### PR TITLE
Use System ACL to get size

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -34,6 +34,7 @@ import hudson.model.View;
 import hudson.model.ViewDescriptor;
 import hudson.model.ViewGroup;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.security.Permission;
 import hudson.util.DescribableList;
 import hudson.views.DefaultViewsTabBar;
@@ -233,7 +234,10 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
          */
         @Override
         public String getDisplayName() {
-            return category.getDisplayName().toString() + " (" + getItems().size() + ")";
+            //Only used to get a count and to prevent poor performance in cases with large number of items
+            try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+                return category.getDisplayName().toString() + " (" + getItems().size() + ")";
+            }
         }
 
         /**

--- a/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
@@ -33,6 +33,7 @@ import hudson.model.View;
 import hudson.model.ViewDescriptor;
 import hudson.model.ViewGroup;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.security.Permission;
 import hudson.views.DefaultViewsTabBar;
 import hudson.views.StatusColumn;
@@ -226,7 +227,10 @@ public class OrganizationFolderViewHolder extends AbstractFolderViewHolder {
          */
         @Override
         public String getDisplayName() {
-            return category.getDisplayName().toString() + " (" + getItems().size() + ")";
+            //Only used to get a count and to prevent poor performance in cases with large number of items
+            try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+                return category.getDisplayName().toString() + " (" + getItems().size() + ")";
+            }
         }
 
         /**


### PR DESCRIPTION
Because the size is within the display name this can lead to poor performing situations especially with repositories with a large number of branches / pull requests. This performs even more poorly in those repositories because the tabs have to be sorted

```
Handling GET /job/org/job/repo from 10.33.250.197 : qtp1738561265-3033572 View/index.jelly DefaultViewsTabBar/viewTabs.jelly
java.lang.Character.toLowerCase(Character.java:6374)
java.lang.Character.toLowerCase(Character.java:6345)
java.lang.String$CaseInsensitiveComparator.compare(String.java:1203)
java.lang.String$CaseInsensitiveComparator.compare(String.java:1186)
java.lang.String.compareToIgnoreCase(String.java:1239)
hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:40)
hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:34)
jenkins.model.IdStrategy$CaseInsensitive.compare(IdStrategy.java:225)
jenkins.model.IdStrategy.equals(IdStrategy.java:120)
nectar.plugins.rbac.groups.Group.isMatch(Group.java:492)
nectar.plugins.rbac.groups.Group.isMatch(Group.java:445)
nectar.plugins.rbac.groups.Group.isMatch(Group.java:382)
nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:196)
nectar.plugins.rbac.groups.GroupContainerACL._hasPermission(GroupContainerACL.java:123)
nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:76)
org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty$1.hasPermission(BranchJobProperty.java:77)
hudson.security.ACL.hasPermission(ACL.java:87)
hudson.security.AccessControlled.hasPermission(AccessControlled.java:54)
com.cloudbees.hudson.plugins.folder.AbstractFolder.getItems(AbstractFolder.java:1014)
com.cloudbees.hudson.plugins.folder.AbstractFolder.getItems(AbstractFolder.java:1004)
hudson.model.ListView.getItems(ListView.java:214)
hudson.model.ListView.getItems(ListView.java:184)
jenkins.branch.MultiBranchProjectViewHolder$ViewImpl.getDisplayName(MultiBranchProjectViewHolder.java:236)
hudson.views.ViewsTabBar$1.compare(ViewsTabBar.java:91)
hudson.views.ViewsTabBar$1.compare(ViewsTabBar.java:88)
java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
java.util.TimSort.sort(TimSort.java:220)
java.util.Arrays.sort(Arrays.java:1512)
java.util.ArrayList.sort(ArrayList.java:1462)
hudson.views.ViewsTabBar.sort(ViewsTabBar.java:88)
```

Since the number is just a count it might make sense to skip these costly permissions checks