### PR TITLE
onDeleted - CleanupTask causing Out Of Memory exception

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -441,12 +441,14 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
         }
         
         private static class CleanupTaskProvisioner implements Runnable{
-              
+            
+            @NonNull
             private final TopLevelItem tli;
             
+            @NonNull
             private final Queue<Node> nodes;
             
-            private static final double MEMORYSATURATIONLIMIT = 85.00;
+            private static final double MEMORY_SATURATION_LIMIT = 85.00;
             
             public CleanupTaskProvisioner(TopLevelItem tli, List<Node> nodes) {
                 this.tli = tli;
@@ -463,7 +465,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                         usedMemoryPercent = calculateUsedMemoryPercentage();
                         // While the maximum usage of Memory is below 85% And Queue isn't empty - Keep spawning threads
                         // If memory limit is exceeded break While Loop - Check if Queue is empty if not - retry
-                        while(usedMemoryPercent <= this.MEMORYSATURATIONLIMIT && !nodes.isEmpty()){
+                        while(usedMemoryPercent <= this.MEMORY_SATURATION_LIMIT && !nodes.isEmpty()){
                             Computer.threadPoolForRemoting.submit(new CleanupTask(tli, nodes.poll()));
                             usedMemoryPercent = calculateUsedMemoryPercentage();
                             LOGGER.log(Level.INFO, "Current used Memory in Percent: {0}%", usedMemoryPercent);

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -471,7 +471,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                         }
                     // If the Queue is empty it will set isRunning to False which will terminated the Loop
                     isRunning = !nodes.isEmpty();
-                }
+                    }   
                 } catch (Exception e) {
                     LOGGER.log(Level.WARNING, e.getMessage());
                 }

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -56,7 +56,6 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -421,7 +421,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                     // Get current used memory as Percentages
                     usedMemoryPercent = (double)usedMemory / totalMemory * 100;
                     // While the maximum usage of Memory is below 85% And Queue isn't empty - Keep spawning threads
-                    // If memory is exceeded break while - Check if list is empty, if not 
+                    // If memory limit is exceeded break while - Check if list is empty, if not retry
                     while(usedMemoryPercent <= 85.00 && !nodes.isEmpty()){
                         Computer.threadPoolForRemoting.submit(new CleanupTask(tli, nodes.poll()));
                         usedMemory = totalMemory - instance.freeMemory();

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -416,7 +416,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             }
             Jenkins jenkins = Jenkins.get();
             Computer.threadPoolForRemoting.submit(new MoveTask(oldFullName, newFullName, jenkins));
-            for (Node node : jenkins.getNodes()) {    
+            for (Node node : jenkins.getNodes()) {
                 Computer.threadPoolForRemoting.submit(new MoveTask(oldFullName, newFullName, node));
             }
         }

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -447,7 +447,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             
             private final Queue<Node> nodes;
             
-            private final double memorySaturationLimit = 85.00;
+            private static final double MEMORYSATURATIONLIMIT = 85.00;
             
             public CleanupTaskProvisioner(TopLevelItem tli, List<Node> nodes) {
                 this.tli = tli;
@@ -464,17 +464,15 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                         usedMemoryPercent = calculateUsedMemoryPercentage();
                         // While the maximum usage of Memory is below 85% And Queue isn't empty - Keep spawning threads
                         // If memory limit is exceeded break While Loop - Check if Queue is empty if not - retry
-                        while(usedMemoryPercent <= this.memorySaturationLimit && !nodes.isEmpty()){
+                        while(usedMemoryPercent <= this.MEMORYSATURATIONLIMIT && !nodes.isEmpty()){
                             Computer.threadPoolForRemoting.submit(new CleanupTask(tli, nodes.poll()));
                             usedMemoryPercent = calculateUsedMemoryPercentage();
                             LOGGER.log(Level.INFO, "Current used Memory in Percent: {0}%", usedMemoryPercent);
                         }
                     // If the Queue is empty it will set isRunning to False which will terminated the Loop
                     isRunning = !nodes.isEmpty();
-                    // Sleep for 2.5 seconds while waiting for Memory to be released(Simply to reduce amount of Loops with non-sufficent memory).
-                    Thread.sleep(2500);
                 }
-                } catch (InterruptedException e) {
+                } catch (Exception e) {
                     LOGGER.log(Level.WARNING, e.getMessage());
                 }
             }

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -465,7 +465,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                         usedMemoryPercent = calculateUsedMemoryPercentage();
                         // While the maximum usage of Memory is below 85% And Queue isn't empty - Keep spawning threads
                         // If memory limit is exceeded break While Loop - Check if Queue is empty if not - retry
-                        while(usedMemoryPercent <= this.MEMORY_SATURATION_LIMIT && !nodes.isEmpty()){
+                        while(usedMemoryPercent <= MEMORY_SATURATION_LIMIT && !nodes.isEmpty()){
                             Computer.threadPoolForRemoting.submit(new CleanupTask(tli, nodes.poll()));
                             usedMemoryPercent = calculateUsedMemoryPercentage();
                             LOGGER.log(Level.INFO, "Current used Memory in Percent: {0}%", usedMemoryPercent);

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -398,7 +398,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
     public static class Deleter extends ItemListener {
 
         @Override
-        public void onDeleted(Item item) {            
+        public void onDeleted(Item item) {
             if (!(item instanceof TopLevelItem)) {
                 return;
             }


### PR DESCRIPTION
The changes made are trying to solve an issue which occurs when there is a large amount of nodes that need their workspace deleted. The idea behind the solution is to have a Thread that works as a provisioner that only executes `ThreadPoolForRemoting.submit()`  if there is sufficient memory. Other users have experienced similar [JENKINS-27514](https://issues.jenkins-ci.org/browse/JENKINS-27514?jql=text%20~%20%22Threadpoolforremoting%22) & [JENKINS-47258](https://issues.jenkins-ci.org/browse/JENKINS-47258?jql=text%20~%20%22Threadpoolforremoting%22).
I do know that it is inherently a problem in Jenkins-Core, we have a Customer that are experiencing an issue when they use Branch-Api to clean up after a job.

So my plan was to alleviate the problem by targeting the specific issue they are experiencing, until the issues in Jenkins-Core can be resolved.
