### PR TITLE
Check OverrideIndexTriggers only when BranchIndexingCause

### DIFF
--- a/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
+++ b/src/main/java/jenkins/branch/NoTriggerBranchProperty.java
@@ -77,14 +77,15 @@ public class NoTriggerBranchProperty extends BranchProperty {
                                 Job<?,?> j = (Job) p;
                                 if (j.getParent() instanceof MultiBranchProject) {
 
-                                    OverrideIndexTriggersJobProperty overrideProp = j.getProperty(OverrideIndexTriggersJobProperty.class);
-                                    if (overrideProp != null) {
-                                        return overrideProp.getEnableTriggers();
-                                    } else {
-                                        for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
-                                            if (prop instanceof NoTriggerBranchProperty) {
-                                                return false;
-                                            }
+                                    if (c instanceof BranchIndexingCause) {
+                                        OverrideIndexTriggersJobProperty overrideProp = j.getProperty(OverrideIndexTriggersJobProperty.class);
+                                        if (overrideProp != null) {
+                                            return overrideProp.getEnableTriggers();
+                                        }
+                                    }
+                                    for (BranchProperty prop : ((MultiBranchProject) j.getParent()).getProjectFactory().getBranch(j).getProperties()) {
+                                        if (prop instanceof NoTriggerBranchProperty) {
+                                            return false;
                                         }
                                     }
                                 }


### PR DESCRIPTION
`OverrideIndexTriggers` property is checked when the cause of the event is both a `BranchIndexingCause` as well as a `BranchEventCause`. That means the intended behavior for indexing will also occur for `SCM` events. For example, if `OverrideIndexTriggers` is `false` on a branch, that would mean that the branch would not build for indexing as well as `SCM` events.

Check for `OverrideIndexTriggersJobProperty` should only occur if the cause was a `BranchIndexingCause` 