### PR TITLE
Do not printStackTrace on an exception you are going to rethrow

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -597,8 +597,8 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 try {
                     sourceActions.put(source.getId(), source.fetchActions(null, listener));
                 } catch (IOException | InterruptedException | RuntimeException e) {
-                    printStackTrace(e, listener.error("[%tc] Could not update folder level actions from source %s",
-                            System.currentTimeMillis(), source.getId()));
+                    listener.error("[%tc] Could not update folder level actions from source %s",
+                            System.currentTimeMillis(), source.getId());
                     throw e;
                 }
             }
@@ -618,17 +618,17 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     try {
                         bc.commit();
                     } catch (IOException | RuntimeException e) {
-                        printStackTrace(e, listener.error("[%tc] Could not persist folder level actions",
-                                System.currentTimeMillis()));
+                        listener.error("[%tc] Could not persist folder level actions",
+                                System.currentTimeMillis());
                         throw e;
                     }
                     if (saveProject) {
                         try {
                             save();
                         } catch (IOException | RuntimeException e) {
-                            printStackTrace(e, listener.error(
+                            listener.error(
                                     "[%tc] Could not persist folder level configuration changes",
-                                    System.currentTimeMillis()));
+                                    System.currentTimeMillis());
                             throw e;
                         }
                     }
@@ -641,8 +641,8 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     source.fetch(new SCMHeadObserverImpl(source, observer, listener, _factory,
                             new IndexingCauseFactory(), null), listener);
                 } catch (IOException | InterruptedException | RuntimeException e) {
-                    printStackTrace(e, listener.error("[%tc] Could not fetch branches from source %s",
-                            System.currentTimeMillis(), source.getId()));
+                    listener.error("[%tc] Could not fetch branches from source %s",
+                            System.currentTimeMillis(), source.getId());
                     throw e;
                 }
             }
@@ -1360,7 +1360,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         } catch (IOException e) {
                             printStackTrace(e, listener.error(e.getMessage()));
                         } catch (InterruptedException e) {
-                            printStackTrace(e, listener.error(e.getMessage()));
+                            listener.error(e.getMessage());
                             throw e;
                         } finally {
                             long end = System.currentTimeMillis();
@@ -1373,8 +1373,8 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         printStackTrace(e, global.error("[%tc] %s encountered an error while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType, eventOrigin, eventTimestamp));
                     } catch (InterruptedException e) {
-                        printStackTrace(e, global.error("[%tc] %s was interrupted while processing %s %s event from %s with timestamp %tc",
-                                System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType, eventOrigin, eventTimestamp));
+                        global.error("[%tc] %s was interrupted while processing %s %s event from %s with timestamp %tc",
+                                System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType, eventOrigin, eventTimestamp);
                         throw e;
                     }
                 }
@@ -1628,7 +1628,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                         } catch (IOException e) {
                             printStackTrace(e, listener.error(e.getMessage()));
                         } catch (InterruptedException e) {
-                            printStackTrace(e, listener.error(e.getMessage()));
+                            listener.error(e.getMessage());
                             throw e;
                         } finally {
                             long end = System.currentTimeMillis();
@@ -1643,10 +1643,10 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
                                 eventOrigin, eventTimestamp));
                     } catch (InterruptedException e) {
-                        printStackTrace(e, global.error(
+                        global.error(
                                 "[%tc] %s was interrupted while processing %s %s event from %s with timestamp %tc",
                                 System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
-                                eventOrigin, eventTimestamp));
+                                eventOrigin, eventTimestamp);
                         throw e;
                     }
                 } else {
@@ -1696,7 +1696,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                             } catch (IOException e) {
                                 printStackTrace(e, listener.error(e.getMessage()));
                             } catch (InterruptedException e) {
-                                printStackTrace(e, listener.error(e.getMessage()));
+                                listener.error(e.getMessage());
                                 throw e;
                             } finally {
                                 long end = System.currentTimeMillis();
@@ -1712,11 +1712,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                     System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
                                     eventOrigin, eventTimestamp));
                         } catch (InterruptedException e) {
-                            printStackTrace(e, global.error(
+                            global.error(
                                     "[%tc] %s was interrupted while processing %s %s event from %s with "
                                             + "timestamp %tc",
                                     System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p), eventDescription, eventType,
-                                    eventOrigin, eventTimestamp));
+                                    eventOrigin, eventTimestamp);
                             throw e;
                         }
                     }
@@ -1812,7 +1812,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                     } catch (IOException e) {
                                         printStackTrace(e, listener.error(e.getMessage()));
                                     } catch (InterruptedException e) {
-                                        printStackTrace(e, listener.error(e.getMessage()));
+                                        listener.error(e.getMessage());
                                         throw e;
                                     }
                                 } catch (IOException e) {
@@ -1823,12 +1823,12 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                             eventDescription, event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    printStackTrace(e, global.error(
+                                    global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
                                             eventDescription, event.getType().name(),
-                                            event.getOrigin(), event.getTimestamp()));
+                                            event.getOrigin(), event.getTimestamp());
                                     throw e;
                                 }
                             }

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -514,17 +514,17 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                     try {
                         bc.commit();
                     } catch (IOException | RuntimeException e) {
-                        printStackTrace(e, listener.error("[%tc] Could not persist folder level actions",
-                                System.currentTimeMillis()));
+                        listener.error("[%tc] Could not persist folder level actions",
+                                System.currentTimeMillis());
                         throw e;
                     }
                     if (saveProject) {
                         try {
                             save();
                         } catch (IOException | RuntimeException e) {
-                            printStackTrace(e, listener.error(
+                            listener.error(
                                     "[%tc] Could not persist folder level configuration changes",
-                                    System.currentTimeMillis()));
+                                    System.currentTimeMillis());
                             throw e;
                         }
                     }
@@ -541,8 +541,8 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                 try {
                     navigator.visitSources(new SCMSourceObserverImpl(listener, observer, navigator, (SCMSourceEvent<?>) null));
                 } catch (IOException | InterruptedException | RuntimeException e) {
-                    printStackTrace(e, listener.error("[%tc] Could not fetch sources from navigator %s",
-                            System.currentTimeMillis(), navigator));
+                    listener.error("[%tc] Could not fetch sources from navigator %s",
+                            System.currentTimeMillis(), navigator);
                     throw e;
                 }
             }
@@ -1168,7 +1168,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                     } catch (IOException e) {
                                         printStackTrace(e, listener.error(e.getMessage()));
                                     } catch (InterruptedException e) {
-                                        printStackTrace(e, listener.error(e.getMessage()));
+                                        listener.error(e.getMessage());
                                         throw e;
                                     } finally {
                                         long end = System.currentTimeMillis();
@@ -1186,12 +1186,12 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                             globalEventDescription, event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    printStackTrace(e, global.error(
+                                    global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
                                             globalEventDescription, event.getType().name(),
-                                            event.getOrigin(), event.getTimestamp()));
+                                            event.getOrigin(), event.getTimestamp());
                                     throw e;
                                 }
                             }
@@ -1248,7 +1248,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                             printStackTrace(e,
                                                     listener.error("Could not fetch metadata from %s", navigator));
                                         } catch (InterruptedException e) {
-                                            printStackTrace(e, listener.error(e.getMessage()));
+                                            listener.error(e.getMessage());
                                             throw e;
                                         }
                                     }
@@ -1287,12 +1287,12 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                             event.getClass().getName(), event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    printStackTrace(e, global.error(
+                                    global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
                                             event.getClass().getName(), event.getType().name(),
-                                            event.getOrigin(), event.getTimestamp()));
+                                            event.getOrigin(), event.getTimestamp());
                                     throw e;
                                 }
                             }
@@ -1358,7 +1358,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                             }
                                         }
                                     } catch (InterruptedException e) {
-                                        printStackTrace(e, listener.error(e.getMessage()));
+                                        listener.error(e.getMessage());
                                         throw e;
                                     } finally {
                                         long end = System.currentTimeMillis();
@@ -1377,12 +1377,12 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                             event.getClass().getName(), event.getType().name(),
                                             event.getOrigin(), event.getTimestamp()));
                                 } catch (InterruptedException e) {
-                                    printStackTrace(e, global.error(
+                                    global.error(
                                             "[%tc] %s was interrupted while processing %s %s event from %s with "
                                                     + "timestamp %tc",
                                             System.currentTimeMillis(), ModelHyperlinkNote.encodeTo(p),
                                             event.getClass().getName(), event.getType().name(),
-                                            event.getOrigin(), event.getTimestamp()));
+                                            event.getOrigin(), event.getTimestamp());
                                     throw e;
                                 }
                             }
@@ -1509,7 +1509,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                     } catch (InterruptedException | IOException x) {
                         throw x;
                     } catch (Exception x) {
-                        x.printStackTrace(listener.error("Failed to create or update a subproject " + projectName));
+                        printStackTrace(x, listener.error("Failed to create or update a subproject " + projectName));
                     }
                 }
 


### PR DESCRIPTION
Noticed in https://github.com/jenkinsci/mercurial-plugin/pull/149 that the `AbortException` gets a stack trace printed (which is wrong—it is a user error) even though https://github.com/jenkinsci/cloudbees-folder-plugin/blob/3afb5acfeeca5a89cf97edc88e8d497b327667c3/src/main/java/com/cloudbees/hudson/plugins/folder/computed/FolderComputation.java#L171-L174 was going to print it politely at the end of the branch indexing log.

You should only print a stack trace if you are _not_ rethrowing an exception.
