### PR TITLE
remove unnecessary build trigger

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -235,12 +235,6 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 }
             }
         }
-        if (Items.currentlyUpdatingByXml()) {
-            fireSCMSourceAfterSave(getSCMSources());
-            if (isBuildable()) {
-                scheduleBuild();
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Remove unnecessary build trigger. 
This a is a revert of PR https://github.com/jenkinsci/branch-api-plugin/pull/158
Actually, the PR-158 introduce a very serious issue. And lots of ppl already suffer from [it](https://github.com/jenkinsci/branch-api-plugin/pull/158#issuecomment-564523966). 

And logically, the code is not suitable. Because clause `Items.currentlyUpdatingByXml()` doesn't judge if the current item is being updated or not. It judges if any config changed by xml. 

Image this situation, I have thousands of multiplebranch jobs to seed with job-dsl. I change one job's  definition, then all the jobs get branch-indexing job scheduled simultaneously. That would overwhelm the github. 

