### PR TITLE
Fix appearance of branch source configuration on Jenkins 2.263 and older

### DIFF
--- a/src/main/resources/jenkins/branch/BranchSource/config.jelly
+++ b/src/main/resources/jenkins/branch/BranchSource/config.jelly
@@ -24,7 +24,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:branch="/lib/branch-api">
   <branch:rowWrapper name="source">
-    <branch:entryWrapper>
+    <branch:entryWrapper colspan="3">
       <input type="hidden" name="stapler-class" value="${sourceDescriptor.clazz.name}"/>
       <branch:blockWrapper>
         <j:scope>


### PR DESCRIPTION
#226 accidentally dropped a `colspan` attribute, breaking the appearance of the `BranchSource` config page. We should fix that and release a fIx before we merge #228 otherwise users running old versions of core will have to update core for the issue to be fixed.

Before this PR:

<img width="950" alt="Screen Shot 2020-11-09 at 16 41 04" src="https://user-images.githubusercontent.com/1068968/98600693-fd56ac80-22ab-11eb-8266-89c113584712.png">


After this PR:

<img width="961" alt="Screen Shot 2020-11-09 at 16 49 28" src="https://user-images.githubusercontent.com/1068968/98600686-f92a8f00-22ab-11eb-9c23-ad53cc25fe4f.png">
