### PR TITLE
Add the ability to limit the number of cleanup threads

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -434,7 +434,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             @NonNull
             private final Queue<Node> nodes;
 
-            private final int threadLimit = Math.max(0, Integer.parseInt(System.getenv("BRANCH_API_THREAD_LIMIT")));
+            private final int threadLimit = getThreadLimit();
 
             public CleanupTaskProvisioner(TopLevelItem tli, List<Node> nodes) {
                 this.tli = tli;
@@ -469,6 +469,19 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                 return currentThreadCount < threadLimit;
             }
 
+            private int getThreadLimit() {
+                String branchApiThreadLimit = System.getenv("BRANCH_API_THREAD_LIMIT");
+                if (branchApiThreadLimit == null) {
+                    return 0;
+                }
+
+                try {
+                    return Integer.parseInt(branchApiThreadLimit);
+                } catch (NumberFormatException e) {
+                    LOGGER.log(Level.SEVERE, "Failed to parse BRANCH_API_THREAD_LIMIT: {0}", branchApiThreadLimit);
+                    return 0;
+                }
+            }
         }
 
         private static class CleanupTask implements Runnable {

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -70,6 +70,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.Jenkins;
 import jenkins.slaves.WorkspaceLocator;
+import jenkins.util.SystemProperties;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
@@ -383,7 +384,7 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
     @Extension
     public static class Deleter extends ItemListener {
 
-        private static final int CLEANUP_THREAD_LIMIT = parseToInt(System.getProperty(Deleter.class.getName() + ".CLEANUP_THREAD_LIMIT", "0"), 0);
+        private static /* almost final */ int CLEANUP_THREAD_LIMIT = SystemProperties.getInteger(Deleter.class.getName() + ".CLEANUP_THREAD_LIMIT", Integer.valueOf(0)).intValue();
 
         @Override
         public void onDeleted(Item item) {
@@ -411,14 +412,6 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
 
         /** Number of {@link CleanupTask} which have been scheduled but not yet completed. */
         private static int runningTasks;
-
-        private static int parseToInt(String input, int defaultValue) {
-            try {
-                return Integer.parseInt(input);
-            } catch(NumberFormatException ex) {
-                return defaultValue;
-            }
-        }
 
         // Visible for testing
         static synchronized void waitForTasksToFinish() throws InterruptedException {

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -50,7 +50,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -425,15 +425,15 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             runningTasks--;
             Deleter.class.notifyAll();
         }
-        
+
         private static class CleanupTaskProvisioner implements Runnable{
-            
+
             @NonNull
             private final TopLevelItem tli;
-            
+
             @NonNull
             private final Queue<Node> nodes;
-            
+
             private final int threadLimit = Math.max(0, Integer.parseInt(System.getenv("BRANCH_API_THREAD_LIMIT")));
 
             public CleanupTaskProvisioner(TopLevelItem tli, List<Node> nodes) {
@@ -443,11 +443,11 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                     LOGGER.log(Level.INFO, "ThreadLimit Loaded from Environment : {0}", threadLimit);
                 }
             }
-            
+
             @Override
             public void run() {
                 try {
-                    while (!nodes.isEmpty()){                   
+                    while (!nodes.isEmpty()){
                         if (hasFreeThreadVolume(threadLimit)) {
                             Computer.threadPoolForRemoting.submit(new CleanupTask(tli, nodes.remove()));
                         } else {
@@ -459,16 +459,16 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
                     LOGGER.log(Level.WARNING, e.getMessage());
                 }
             }
-            
+
             private boolean hasFreeThreadVolume(int threadLimit){
                 if (threadLimit <= 0) {
                     return true;
                 }
                 int currentThreadCount = ManagementFactory.getThreadMXBean().getThreadCount();
-            
+
                 return currentThreadCount < threadLimit;
             }
-            
+
         }
 
         private static class CleanupTask implements Runnable {
@@ -665,5 +665,5 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             }
         }
 
-    }   
+    }
 }


### PR DESCRIPTION
[First PR](https://github.com/jenkinsci/branch-api-plugin/pull/214) The first PR i made was intended to resolve the issue which was caused by 'onDeleted'. After having the changes run that the issue wasn't memory related but rather the OOM exception was raised after the agents disconnected. 

So this is the second draft trying to resolve this issue, so far this has been running for more than 2 weeks without any issues.
The idea is to let the users set a limit for how many threads can run in Jenkins, and if that cap is reached the 'onDeleted' will wait with spawning new threads until the limit isn't reached. 

This might be a crude way to implement this check, it might be better to try at set the limit on only the plugin instead of Jenkins instance.

I'm hoping this might be useful as is and in the very least, spark a discussion about how we might resolve this.  
 