### PR TITLE
Tweak semantics for BRANCH_IS_PRIMARY env var

### DIFF
--- a/src/main/java/jenkins/branch/BranchNameContributor.java
+++ b/src/main/java/jenkins/branch/BranchNameContributor.java
@@ -64,8 +64,6 @@ public class BranchNameContributor extends EnvironmentContributor {
                 envs.put("BRANCH_NAME", head.getName());
                 if (branch.getAction(PrimaryInstanceMetadataAction.class) != null) {
                     envs.put("BRANCH_IS_PRIMARY", "true");
-                } else {
-                    envs.put("BRANCH_IS_PRIMARY", "false");
                 }
                 if (head instanceof ChangeRequestSCMHead) {
                     envs.putIfNotNull("CHANGE_ID", ((ChangeRequestSCMHead) head).getId());

--- a/src/main/resources/jenkins/branch/BranchNameContributor/buildEnv.properties
+++ b/src/main/resources/jenkins/branch/BranchNameContributor/buildEnv.properties
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 blurb.BRANCH_NAME=For a multibranch project, this will be set to the name of the branch being built, for example in case you wish to deploy to production from <code>master</code> but not from feature branches; if corresponding to some kind of change request, the name is generally arbitrary (refer to <code>CHANGE_ID</code> and <code>CHANGE_TARGET</code>).
-blurb.BRANCH_IS_PRIMARY=For a multibranch project, if the SCM source reports that the branch being built is a primary branch, this will be set to <code>true</code>, otherwise this will be set to <code>false</code>. Some SCM sources may report more than one branch as a primary branch while others may not supply this information. 
+blurb.BRANCH_IS_PRIMARY=For a multibranch project, if the SCM source reports that the branch being built is a primary branch, this will be set to <code>"true"</code>; else unset. Some SCM sources may report more than one branch as a primary branch while others may not supply this information. 
 blurb.CHANGE_ID=For a multibranch project corresponding to some kind of change request, this will be set to the change ID, such as a pull request number, if supported; else unset.
 blurb.CHANGE_URL=For a multibranch project corresponding to some kind of change request, this will be set to the change URL, if supported; else unset.
 blurb.CHANGE_TITLE=For a multibranch project corresponding to some kind of change request, this will be set to the title of the change, if supported; else unset.

--- a/src/test/java/jenkins/branch/BranchNameContributorTest.java
+++ b/src/test/java/jenkins/branch/BranchNameContributorTest.java
@@ -99,15 +99,14 @@ public class BranchNameContributorTest {
             assertThat("We now have the primary branch", primaryBranch, notNullValue());
             EnvVars env = new EnvVars();
             instance.buildEnvironmentFor(master, env, new LogTaskListener(LOGGER, Level.FINE));
-            assertThat(env.keySet(), containsInAnyOrder(is("BRANCH_NAME"), is("BRANCH_IS_PRIMARY")));
+            assertThat(env.keySet(), contains(is("BRANCH_NAME")));
             assertThat(env.get("BRANCH_NAME"), is("master"));
-            assertThat(env.get("BRANCH_IS_PRIMARY"), is("false"));
+            assertThat(env.keySet(), not(contains(is("BRANCH_IS_PRIMARY"))));
 
             env = new EnvVars();
             instance.buildEnvironmentFor(cr1, env, new LogTaskListener(LOGGER, Level.FINE));
             assertThat(env.keySet(), containsInAnyOrder(
                     is("BRANCH_NAME"),
-                    is("BRANCH_IS_PRIMARY"),
                     is("CHANGE_ID"),
                     is("CHANGE_TARGET"),
                     is("CHANGE_TITLE"),
@@ -118,7 +117,7 @@ public class BranchNameContributorTest {
                     is("CHANGE_AUTHOR_DISPLAY_NAME")
             ));
             assertThat(env.get("BRANCH_NAME"), is("CR-" + cr1Num));
-            assertThat(env.get("BRANCH_IS_PRIMARY"), is("false"));
+            assertThat(env.keySet(), not(contains(is("BRANCH_IS_PRIMARY"))));
             assertThat(env.get("CHANGE_ID"), is(cr1Num.toString()));
             assertThat(env.get("CHANGE_TARGET"), is("master"));
             assertThat(env.get("CHANGE_BRANCH"), is("CR-" + cr1Num));
@@ -132,7 +131,6 @@ public class BranchNameContributorTest {
             instance.buildEnvironmentFor(cr2, env, new LogTaskListener(LOGGER, Level.FINE));
             assertThat(env.keySet(), containsInAnyOrder(
                     is("BRANCH_NAME"),
-                    is("BRANCH_IS_PRIMARY"),
                     is("CHANGE_ID"),
                     is("CHANGE_TARGET"),
                     is("CHANGE_TITLE"),
@@ -144,7 +142,7 @@ public class BranchNameContributorTest {
                     is("CHANGE_AUTHOR_DISPLAY_NAME")
             ));
             assertThat(env.get("BRANCH_NAME"), is("CR-" + cr2Num));
-            assertThat(env.get("BRANCH_IS_PRIMARY"), is("false"));
+            assertThat(env.keySet(), not(contains(is("BRANCH_IS_PRIMARY"))));
             assertThat(env.get("CHANGE_ID"), is(cr2Num.toString()));
             assertThat(env.get("CHANGE_TARGET"), is("master"));
             assertThat(env.get("CHANGE_BRANCH"), is("CR-" + cr2Num));
@@ -159,14 +157,13 @@ public class BranchNameContributorTest {
             instance.buildEnvironmentFor(tag, env, new LogTaskListener(LOGGER, Level.FINE));
             assertThat(env.keySet(), containsInAnyOrder(
                     is("BRANCH_NAME"),
-                    is("BRANCH_IS_PRIMARY"),
                     is("TAG_NAME"),
                     is("TAG_TIMESTAMP"),
                     is("TAG_UNIXTIME"),
                     is("TAG_DATE")
             ));
             assertThat(env.get("BRANCH_NAME"), is("v1.0"));
-            assertThat(env.get("BRANCH_IS_PRIMARY"), is("false"));
+            assertThat(env.keySet(), not(contains(is("BRANCH_IS_PRIMARY"))));
             assertThat(env.get("TAG_NAME"), is("v1.0"));
             assertThat(env.get("TAG_TIMESTAMP"), not(is("")));
             assertThat(env.get("TAG_UNIXTIME"), not(is("")));


### PR DESCRIPTION
Instead of setting "false" in cases where the branch isn't a primary
branch, don't set the variable at all.

The goal is to make using the value easier and less error-prone. Since
the string "false" is truthy in most contexts, e.g. in
Groovy/Jenkinsfile pipelines and related scripts, its use can lead to
unexpected behavior if evaluated in a condition without first performing
an explicit type conversion.

Additionally, it's already a common practice among most consumers of
such "Boolean" environment variables to treat a nonempty value as an
indication of truth. (cf. the `CI` environment variable)

Related: #236.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
