### PR TITLE
[JENKINS-63344] Add a feature flag to be able to disable running SCM branch source scanning when job XMLs are updated

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -34,6 +34,7 @@ import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import com.thoughtworks.xstream.XStreamException;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
 import hudson.Extension;
 import hudson.Util;
@@ -113,6 +114,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
+import jenkins.util.SystemProperties;
 
 import static hudson.Functions.printStackTrace;
 
@@ -125,6 +127,10 @@ import static hudson.Functions.printStackTrace;
 public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         R extends Run<P, R>>
         extends ComputedFolder<P> implements SCMSourceOwner, IconSpec {
+
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Accessible via System Groovy Scripts")
+    private static /* not final */ boolean FIRE_SCM_SOURCE_BUILDS_AFTER_SAVE =
+        SystemProperties.getBoolean(MultiBranchProject.class.getName() + ".fireSCMSourceBuildsAfterSave", true);
 
     /**
      * Our logger.
@@ -233,7 +239,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 }
             }
         }
-        if (Items.currentlyUpdatingByXml()) {
+        if (Items.currentlyUpdatingByXml() && FIRE_SCM_SOURCE_BUILDS_AFTER_SAVE) {
             fireSCMSourceAfterSave(getSCMSources());
             if (isBuildable()) {
                 scheduleBuild();

--- a/src/test/java/integration/UpdatingFromXmlWithDisabledFlagTest.java
+++ b/src/test/java/integration/UpdatingFromXmlWithDisabledFlagTest.java
@@ -8,7 +8,9 @@ import org.apache.commons.io.input.ReaderInputStream;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.FlagRule;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
@@ -16,7 +18,7 @@ import java.io.StringReader;
 
 import static junit.framework.TestCase.assertTrue;
 
-public class UpdatingFromXmlTest {
+public class UpdatingFromXmlWithDisabledFlagTest {
 
     /**
      * All tests in this class only create items and do not affect other global configuration, thus we trade test
@@ -24,6 +26,9 @@ public class UpdatingFromXmlTest {
      */
     @ClassRule
     public static JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public FlagRule flagRule = FlagRule.systemProperty("jenkins.branch.MultiBranchProject.fireSCMSourceBuildsAfterSave", "false");
 
     @Before
     public void cleanOutAllItems() throws Exception {
@@ -33,7 +38,7 @@ public class UpdatingFromXmlTest {
     }
 
     @Test
-    public void given_multibranch_when_createFromXml_then_hasItems() throws Exception {
+    public void given_multibranch_when_createFromXml_is_disabled_then_hasNoItems() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             c.createRepository("foo");
             c.cloneBranch("foo", "master", "feature");
@@ -41,12 +46,12 @@ public class UpdatingFromXmlTest {
             String configXml = IOUtils.toString(getClass().getResourceAsStream("UpdatingFromXmlTest/config.xml")).replace("fixme", c.getId());
             BasicMultiBranchProject prj = (BasicMultiBranchProject) r.jenkins.createProjectFromXML("foo", new ReaderInputStream(new StringReader(configXml)));
             r.waitUntilNoActivity();
-            assertTrue(prj.getItems().size() > 0);
+            assertTrue(prj.getItems().isEmpty());
         }
     }
 
     @Test
-    public void given_multibranch_when_updateFromXml_then_hasItems() throws Exception {
+    public void given_multibranch_when_updateFromXml_is_disabled_then_hasNoItems() throws Exception {
         try (MockSCMController c = MockSCMController.create()) {
             c.createRepository("foo");
             c.cloneBranch("foo", "master", "feature");
@@ -55,7 +60,7 @@ public class UpdatingFromXmlTest {
             BasicMultiBranchProject prj = r.jenkins.createProject(BasicMultiBranchProject.class, "foo");
             prj.updateByXml((Source) new StreamSource(new StringReader(configXml)));
             r.waitUntilNoActivity();
-            assertTrue(prj.getItems().size() > 0);
+            assertTrue(prj.getItems().isEmpty());
         }
     }
 


### PR DESCRIPTION
This pull request adds a feature flag to allow users to disable a very annoying and serious issue when Jenkins contains many jobs and uses Bitbucket or Github with Job DSL plugin.

Be disabling this setting it will avoid causing hundreds of unnecessary calls and then get to the API rate limit of Bitbucket or Github.

This PR will replace the need for #225.
It also closes this issue on Jenkins https://issues.jenkins.io/browse/JENKINS-63344?attachmentViewMode=list.
