### PR TITLE
No need to override `reuseForks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.26</version>
+    <version>4.31</version>
     <relativePath />
   </parent>
 
@@ -144,17 +144,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <reuseForks>false</reuseForks> <!-- TODO reuse seems to cause problems with GitSampleRepoRule -->
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>


### PR DESCRIPTION
As of https://github.com/jenkinsci/plugin-pom/pull/453. Supersedes #282.
