### PR TITLE
JENKINS-67725 - Extending BranchBuildStrategies to allow setting last revision built

### DIFF
--- a/src/main/java/jenkins/branch/BranchBuildStrategy.java
+++ b/src/main/java/jenkins/branch/BranchBuildStrategy.java
@@ -274,6 +274,33 @@ public abstract class BranchBuildStrategy extends AbstractDescribableImpl<Branch
         return isAutomaticBuild(source, head, currRevision, lastBuiltRevision, lastSeenRevision, listener);
     }
 
+
+
+
+
+    /**
+     * API:Should we update last built revision if we did not do a build?
+     *
+     * @return {@code true} if and only if we should consider whatever commit we received as built.
+     */
+    @SuppressWarnings("deprecation")
+    public final boolean updatingLastBuiltRevisionWithNoBuild() {
+        return isUpdatingLastBuiltRevisionWithNoBuild(new LogTaskListener(Logger.getLogger(getClass().getName()), Level.INFO));
+    }
+
+    /**
+     * SPI: Should we update last built revision if we did not do a build?
+     *
+     * @param listener     the TaskListener to be used
+     * @return {@code true} if and only if we should consider whatever commit we received as built.
+     */
+    @Restricted(ProtectedExternally.class)
+    public boolean isUpdatingLastBuiltRevisionWithNoBuild(@NonNull TaskListener listener) {
+        return false;
+    }
+
+
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
See [JENKINS-67725](https://issues.jenkins.io/browse/JENKINS-67725) for more context.  

The basic use case:

- How do we enable the folks to "save" the first commit ID found, and only build everything after that.
- I realize this PR will probably not be merged.  But it is meant to be a conversation.

Discussion
- As written [this](https://github.com/jenkinsci/branch-api-plugin/blob/master/src/main/java/jenkins/branch/MultiBranchProject.java#L2017) will always evaluate to true even if a BuildStrategy keeps responding, do not build.  The next time a branch indexing comes in, it will evaluate to true since it did not build.  This feels like a design flaw.  As a plugin author I am telling you to not build it.  As a Jenkins Admin I am telling you not to build it.  But you are repeatedly trying to build it if I turn on branch indexing.
- As I see it we have 2 options
   - We extend BranchBuildStrategy and add another optional method that allows a plugin author to own if you can update the last built hash 
- We create a whole new extension point to give a plugin author the ability to define what `changesDetected` means.

# What is in the PR
- Added a new extension method(optional) for plugin authors can choose to update last built revision or not.  Default is false which is current behavior
- Added integration of new method into MultiBranchProject to evaluate if it should update lastbuiltrevision on disk.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


