### PR TITLE
Fix missing help button on modern Jenkins versions

### DIFF
--- a/src/main/resources/lib/branch-api/branchSourceBody.jelly
+++ b/src/main/resources/lib/branch-api/branchSourceBody.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
         </div>
         <j:if test="${help!=null}">
           <div>
-            <a href="#" class="help-button" helpURL="${rootURL}${help}"><img src="${imagesURL}/16x16/help.png" alt="[help]" height="16" width="16"/></a>
+            <a href="#" class="help-button" helpURL="${rootURL}${help}"><l:icon class="icon-help icon-md" alt="[help]"/></a>
           </div>
         </j:if>
       </div>


### PR DESCRIPTION
The change proposed addresses Mark's comment on my [core PR](https://github.com/jenkinsci/jenkins/pull/6280#issuecomment-1043356722) about the broken help icon.

Edit: To note, this will only work on my core PR, if someone tests that on the current weekly.