### PR TITLE
JENKINS-68116 Increase log size limit

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -1138,7 +1138,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     250, TimeUnit.MILLISECONDS,
                     1024,
                     true,
-                    32 * 1024,
+                    FileUtils.ONE_MB * 10,
                     5
             );
         }

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -1163,8 +1163,9 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 String eventType = event.getType().name();
                 String eventOrigin = event.getOrigin();
                 long eventTimestamp = event.getTimestamp();
+                long started = System.currentTimeMillis();
                 global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
-                        System.currentTimeMillis(), eventDescription, eventType, eventOrigin,
+                        started, eventDescription, eventType, eventOrigin,
                         eventTimestamp);
                 LOGGER.log(Level.FINE, "{0} {1} {2,date} {2,time}: onSCMHeadEvent",
                         new Object[]{
@@ -1201,10 +1202,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     printStackTrace(e, global.error("[%tc] Interrupted while processing %s %s event from %s with timestamp %tc",
                             System.currentTimeMillis(), eventDescription, eventType, eventOrigin, eventTimestamp));
                 }
+                long ended = System.currentTimeMillis();
                 global.getLogger()
-                        .format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
-                                System.currentTimeMillis(), eventDescription, eventType, eventOrigin,
-                                eventTimestamp, matchCount);
+                        .format(OrganizationFolder.COMPLETED_PROCESSING_EVENT,
+                                ended, eventDescription, eventType, eventOrigin,
+                                eventTimestamp, ended - started, matchCount);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Could not close global event log file", e);
             }
@@ -1727,8 +1729,9 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
         public void onSCMSourceEvent(SCMSourceEvent<?> event) {
             try (StreamTaskListener global = globalEventsListener()) {
                 String eventDescription = StringUtils.defaultIfBlank(event.description(), event.getClass().getName());
+                long started = System.currentTimeMillis();
                 global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
-                        System.currentTimeMillis(), eventDescription, event.getType().name(),
+                    started, eventDescription, event.getType().name(),
                         event.getOrigin(), event.getTimestamp());
                 int matchCount = 0;
                 // not interested in creation as that is an event for org folders
@@ -1835,10 +1838,11 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                                 event.getOrigin(), event.getTimestamp()));
                     }
                 }
+                long ended = System.currentTimeMillis();
                 global.getLogger()
-                        .format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
-                                System.currentTimeMillis(), eventDescription, event.getType().name(),
-                                event.getOrigin(), event.getTimestamp(), matchCount);
+                        .format(OrganizationFolder.COMPLETED_PROCESSING_EVENT,
+                                ended, eventDescription, event.getType().name(),
+                                event.getOrigin(), event.getTimestamp(), ended - started, matchCount);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Could not close global event log file", e);
             }

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -1138,7 +1138,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                     250, TimeUnit.MILLISECONDS,
                     1024,
                     true,
-                    FileUtils.ONE_MB * 10,
+                    FileUtils.ONE_MB,
                     5
             );
         }

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -124,6 +124,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
      * Our logger.
      */
     private static final Logger LOGGER = Logger.getLogger(OrganizationFolder.class.getName());
+    static final String COMPLETED_PROCESSING_EVENT = "[%tc] Finished processing %s %s event from %s with timestamp %tc, processed in %dms. Matched %d.%n";
     /**
      * Our navigators.
      */
@@ -982,8 +983,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
         public void onSCMHeadEvent(SCMHeadEvent<?> event) {
             try (StreamTaskListener global = globalEventsListener()) {
                 String globalEventDescription = StringUtils.defaultIfBlank(event.description(), event.getClass().getName());
+                long started = System.currentTimeMillis();
                 global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
-                        System.currentTimeMillis(),
+                        started,
                         globalEventDescription,
                         event.getType().name(),
                         event.getOrigin(), event.getTimestamp());
@@ -1087,10 +1089,11 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                 event.getOrigin(), event.getTimestamp()));
                     }
                 }
+                long ended = System.currentTimeMillis();
                 global.getLogger()
-                        .format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
-                                System.currentTimeMillis(), globalEventDescription, event.getType().name(),
-                                event.getOrigin(), event.getTimestamp(), matchCount);
+                        .format(COMPLETED_PROCESSING_EVENT,
+                                ended, globalEventDescription, event.getType().name(),
+                                event.getOrigin(), event.getTimestamp(), ended - started,  matchCount);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Could not close global event log file", e);
             }
@@ -1103,8 +1106,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
         @Override
         public void onSCMNavigatorEvent(SCMNavigatorEvent<?> event) {
             try (StreamTaskListener global = globalEventsListener()) {
+                long started = System.currentTimeMillis();
                 global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
-                        System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
+                    started, event.getClass().getName(), event.getType().name(),
                         event.getOrigin(), event.getTimestamp());
                 int matchCount = 0;
                 if (UPDATED == event.getType()) {
@@ -1188,10 +1192,11 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                 event.getOrigin(), event.getTimestamp()));
                     }
                 }
+                long ended = System.currentTimeMillis();
                 global.getLogger()
-                        .format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
-                                System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                                event.getOrigin(), event.getTimestamp(), matchCount);
+                        .format(OrganizationFolder.COMPLETED_PROCESSING_EVENT,
+                            ended, event.getClass().getName(), event.getType().name(),
+                                event.getOrigin(), event.getTimestamp(), ended - started, matchCount);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Could not close global event log file", e);
             }
@@ -1203,8 +1208,9 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
         @Override
         public void onSCMSourceEvent(SCMSourceEvent<?> event) {
             try (StreamTaskListener global = globalEventsListener()) {
+                long started = System.currentTimeMillis();
                 global.getLogger().format("[%tc] Received %s %s event from %s with timestamp %tc%n",
-                        System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
+                    started, event.getClass().getName(), event.getType().name(),
                         event.getOrigin(), event.getTimestamp());
                 int matchCount = 0;
                 if (CREATED == event.getType()) {
@@ -1278,10 +1284,11 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                 event.getOrigin(), event.getTimestamp()));
                     }
                 }
+                long ended = System.currentTimeMillis();
                 global.getLogger()
-                        .format("[%tc] Finished processing %s %s event from %s with timestamp %tc. Matched %d.%n",
-                                System.currentTimeMillis(), event.getClass().getName(), event.getType().name(),
-                                event.getOrigin(), event.getTimestamp(), matchCount);
+                        .format(OrganizationFolder.COMPLETED_PROCESSING_EVENT,
+                            ended, event.getClass().getName(), event.getType().name(),
+                                event.getOrigin(), event.getTimestamp(), ended - started, matchCount);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Could not close global event log file", e);
             }
@@ -1335,7 +1342,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                     for (SCMSource source : sources) {
                         BranchSource branchSource = new BranchSource(source);
                         branchSource.setBuildStrategies(buildStrategies);
-                        branchSource.setStrategy(strategy); 
+                        branchSource.setStrategy(strategy);
                         branchSources.add(branchSource);
                     }
                     return branchSources;


### PR DESCRIPTION
Previously each log file was limited to 33KB and 5 files.
On our busy Jenkins instance we only got 15 minutes worth of logs before
they were rotated out.

It would be good for this to be increased to make analysis of issues
easier

see https://issues.jenkins.io/browse/JENKINS-68116