### PR TITLE
Remove obsolete FindBugs configuration

### DIFF
--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,5 +1,0 @@
-<FindBugsFilter>
-  <Match>
-    <Class name="~.*\.Messages"/>
-  </Match>
-</FindBugsFilter>


### PR DESCRIPTION
This file has long been unused by the build process since we moved from FindBugs to SpotBugs years ago.