### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <revision>2</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     <no-test-jar>false</no-test-jar>
   </properties>
@@ -77,8 +77,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>1750.v0071fa_4c4a_e3</version>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2143.ve4c3c9ec790a</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,12 +125,16 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
+      <!-- TODO: Remove version declaration when git plugin 5.1.0 is in plugin BOM -->
+      <version>5.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <!-- TODO: Remove version declaration when git plugin 5.1.0 is in plugin BOM -->
+      <version>5.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.63</version>
+    <version>4.66</version>
     <relativePath/>
   </parent>
 

--- a/src/test/java/integration/BrandingTest.java
+++ b/src/test/java/integration/BrandingTest.java
@@ -25,8 +25,8 @@
 
 package integration;
 
-import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlAnchor;
+import org.htmlunit.html.HtmlPage;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Action;


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

Require Jenkins 2.387.3 or newer so that we can upgrade HTMLUnit from 2.x to 3.x and so that users are not mislead to thinking that we are actively testing older versions of Jenkins.

* Require Jenkins 2.387.3 or newer
* Require git plugin 5.1.0 or newer

Includes changes from:

* #378
* #377 

Supersedes pull requests:

* #375

### Testing done

Compiled plugin and all tests passed.  Will include in my Jenkins installation after an incremental build is available.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
