### PR TITLE
[JENKINS-55348] Fix branch view and documentation

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProjectDisplayNamingStrategy.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectDisplayNamingStrategy.java
@@ -24,6 +24,7 @@
 package jenkins.branch;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
 import jenkins.scm.api.metadata.ObjectMetadataAction;
 import org.jvnet.localizer.Localizable;
 
@@ -42,7 +43,7 @@ public enum MultiBranchProjectDisplayNamingStrategy {
     OBJECT_DISPLAY_NAME(true, Messages._MultiBranchProjectDisplayNamingTrait_DisplayName()) {
         @Override
         public String generateName(@NonNull final String rawName, final String displayName) {
-            return displayName;
+            return isBlank(displayName) ? rawName : displayName;
         }
     },
     /**
@@ -51,7 +52,15 @@ public enum MultiBranchProjectDisplayNamingStrategy {
     RAW_AND_OBJECT_DISPLAY_NAME(true, Messages._MultiBranchProjectDisplayNamingTrait_RawAndDisplayName()) {
         @Override
         public String generateName(@NonNull final String rawName, final String displayName) {
-            return isBlank(displayName) ? rawName : format("%s: %s", rawName, displayName);
+            if (isBlank(displayName)) {
+                return rawName;
+            }
+
+            if (Objects.equals(rawName, displayName)) {
+                return rawName;
+            }
+
+            return format("%s - %s", rawName, displayName);
         }
     },
     ;
@@ -67,6 +76,7 @@ public enum MultiBranchProjectDisplayNamingStrategy {
     public boolean needsObjectDisplayName() {
         return needsObjectDisplayName;
     }
+
     public String getDisplayName() {
         return displayName.toString();
     }

--- a/src/main/resources/jenkins/branch/MultiBranchProjectDisplayNamingTrait/help-displayNamingStrategy.html
+++ b/src/main/resources/jenkins/branch/MultiBranchProjectDisplayNamingTrait/help-displayNamingStrategy.html
@@ -1,13 +1,23 @@
 <div>
-    The different strategies:
-    <ul>
-        <li>
-            <strong>Object display name:</strong>
-            <span>Uses the branch source plugin's display name for the PR instead of the raw name</span>
-        </li>
-        <li>
-            <strong>Raw and object display name:</strong>
-            <span>Joins the raw name and the branch source plugin's display name</span>
-        </li>
-    </ul>
+  The different strategies:
+  <ul>
+    <li>
+      <span>
+        <strong>Job display name with fallback to name:</strong>
+        <br>
+        <span>Uses the branch source plugin's display name for the PR instead of the raw name</span>
+        <br>
+        <span>Value for configuration-as-code: <code>OBJECT_DISPLAY_NAME</code></span>
+      </span>
+    </li>
+    <li>
+      <span>
+        <strong>Name and, if available, display name:</strong>
+        <br>
+        <span>Joins the raw name and the branch source plugin's display name</span>
+        <br>
+        <span>Value for configuration-as-code: <code>RAW_AND_OBJECT_DISPLAY_NAME</code></span>
+      </span>
+    </li>
+  </ul>
 </div>


### PR DESCRIPTION
# Goal of this PR ([Original Issue](https://issues.jenkins.io/browse/JENKINS-55348))

Fix small mistakes with previous PR on naming strategies:

* The branch view was uglified by the previous PR on some SCM sources because they fill the name __and__ display name with the same value. The current implementation of the code displays something like this in the branch view for these cases: `master: master`
* The separator that was chosen `:` may not be the best option because it's already rather heavily used in the display names. Ex: on GitHub, it's frequent to use a commit message as the PR's title to benefit from squash & merge feature. Popular commit message templates tend to use colons which makes things hard to read. I switched to using `-` in this PR as it's done in the screenshot in the original issue because it looks better.
* A user pointed out in the original issue's comments that the documentation for the display naming strategy didn't match the drop-down list's phrasing. I've fixed it, and added more documentation to help people link the behaviors with the enum values (for people using Job DSL)
