### PR TITLE
`RateLimitBranchProperty`: Fix checking queue for other items tied to the same task

### DIFF
--- a/src/main/java/jenkins/branch/RateLimitBranchProperty.java
+++ b/src/main/java/jenkins/branch/RateLimitBranchProperty.java
@@ -533,22 +533,23 @@ public class RateLimitBranchProperty extends BranchProperty {
                     }
                     // ensure items leave the queue in the order they were scheduled
                     List<Queue.Item> items = Jenkins.get().getQueue().getItems(item.task);
-                    if (!items.isEmpty()) {
-                        Queue.Item i = items.get(0);
-                        if (item == i) { // This item is the first in queue for this task.
-                            LOGGER.log(Level.FINE, () -> "Allowing " + item.getId() + " " + item.getClass().getSimpleName() + " " + job.getFullName());
-                            return null;
-                        } else {
-                            // There is another item before the one currently processed, so block.
-                            LOGGER.log(Level.FINE, () -> item.getId() + " " + job.getFullName() + " blocked by queue id " + i.getId() + " was first");
+                    if (items.size() == 1 && item == items.get(0)) {
+                        return null;
+                    }
+                    for (Queue.Item i : items) {
+                        if (i.getInQueueSince() < item.getInQueueSince()) {
+                            LOGGER.log(Level.FINE, "{0} with queue id {1} blocked by queue id {2} was first",
+                                    new Object[]{
+                                            job.getFullName(),
+                                            item.getId(),
+                                            i.getId()
+                                    }
+                            );
                             long betweenBuilds = property.getMillisecondsBetweenBuilds();
                             return CauseOfBlockage.fromMessage(Messages._RateLimitBranchProperty_BuildBlocked(
                                     new Date(System.currentTimeMillis() + betweenBuilds))
                             );
                         }
-                    } else {
-                        // Defensive measure, the queue item is supposed to be in queue already.
-                        LOGGER.log(Level.WARNING, "Could not find queue item with id=" + item.getId() + " in queue.");
                     }
                 }
             }

--- a/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/RateLimitBranchPropertyTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
@@ -51,6 +52,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -84,6 +86,9 @@ public class RateLimitBranchPropertyTest {
      */
     @ClassRule
     public static JenkinsRule r = new JenkinsRule();
+
+    @ClassRule
+    public static LoggerRule loggerRule = new LoggerRule().record(RateLimitBranchProperty.class, Level.FINE);
     /**
      * Our logger.
      */


### PR DESCRIPTION
`getId` is not comparable, but `getInQueueSince` is.

This also adds a `LoggerRule` to the test class to make the test output more readable.

cc @jglick 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
