### PR TITLE
remove lib.form.hetero-list.hetero-list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <revision>2</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.426</jenkins.version>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     <no-test-jar>false</no-test-jar>
   </properties>
@@ -77,8 +77,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2465.va_e76ed7b_3061</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>2555.v3190a_8a_c60c6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/resources/lib/branch-api/branchSourceSelector.jelly
+++ b/src/main/resources/lib/branch-api/branchSourceSelector.jelly
@@ -96,7 +96,7 @@ THE SOFTWARE.
     </div>
 
     <div>
-      <button type="button" class="hetero-list-add" menualign="${attrs.menuAlign}" suffix="${attrs.field}">${attrs.addCaption?:'%Add'}<l:icon src="symbol-chevron-down"/>
+      <input type="button" value="${attrs.addCaption?:'%Add'}" class="hetero-list-add" menualign="${attrs.menuAlign}" suffix="${attrs.field}"/>
     </div>
   </div>
 </j:jelly>

--- a/src/main/resources/lib/branch-api/branchSourceSelector.jelly
+++ b/src/main/resources/lib/branch-api/branchSourceSelector.jelly
@@ -56,7 +56,6 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-  <st:adjunct includes="lib.form.hetero-list.hetero-list"/>
   <f:prepareDatabinding />
   <j:set target="${attrs}" property="descriptors"
          value="${attrs.descriptors ?: descriptor.getPropertyType(instance,attrs.field).getApplicableDescriptors()}" />
@@ -97,7 +96,7 @@ THE SOFTWARE.
     </div>
 
     <div>
-      <input type="button" value="${attrs.addCaption?:'%Add'}" class="hetero-list-add" menualign="${attrs.menuAlign}" suffix="${attrs.field}"/>
+      <button type="button" class="hetero-list-add" menualign="${attrs.menuAlign}" suffix="${attrs.field}">${attrs.addCaption?:'%Add'}<l:icon src="symbol-chevron-down"/>
     </div>
   </div>
 </j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
See https://github.com/jenkinsci/jenkins/pull/8418#discussion_r1337479191

`hetero-list` adjunct was removed in  https://github.com/jenkinsci/jenkins/pull/8418
If this adjunct gets called, a large stack trace error should appear in the logs.

### Testing done
adjunct resides in `branchSourceSelector.jelly`, which is called by `configure-branches.jelly`, then `configure-entries.jelly` from `MultibranchProject`. Tested under a local instance using a github multibranch folder ~but have not been able to extract any errors~ and was able to generate an error. This PR + https://github.com/jenkinsci/scm-api-plugin/pull/228 removes the error

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
