### PR TITLE
Require Jenkins 2.426.1 instead of 2.426

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>2555.v3190a_8a_c60c6</version>
+        <version>2612.v3d6a_2128c0ef</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <revision>2</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.426</jenkins.version>
+    <jenkins.version>2.426.1</jenkins.version>
     <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
     <no-test-jar>false</no-test-jar>
   </properties>


### PR DESCRIPTION
## Require Jenkins 2.426.1, not 2.426

Jenkins plugin bill of materials bom-2.426.x now requires Jenkins 2.426.1 rather than 2.426 as its minimum version.

Includes pull requests:

* #419
* #414

### Testing done

Rely on ci.jenkins.io to run automated tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
