### PR TITLE
Adapt the standard Jenkins icons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,10 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>ionicons-api</artifactId>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/resources/jenkins/branch/MultiBranchProjectEmptyView/main.jelly
+++ b/src/main/resources/jenkins/branch/MultiBranchProjectEmptyView/main.jelly
@@ -41,7 +41,7 @@
           <a href="./configure" class="content-block__link">
             <span>Configure the project</span>
             <span class="trailing-icon">
-              <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px" />
+              <l:icon class="icon-sm" src="symbol-arrow-forward-outline plugin-ionicons-api" />
             </span>
           </a>
         </li>
@@ -49,7 +49,7 @@
           <a href="./indexing" class="content-block__link">
             <span>Re-index branches</span>
             <span class="trailing-icon">
-              <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px" />
+              <l:icon class="icon-sm" src="symbol-arrow-forward-outline plugin-ionicons-api" />
             </span>
           </a>
         </li>

--- a/src/main/resources/jenkins/branch/OrganizationFolderEmptyView/main.jelly
+++ b/src/main/resources/jenkins/branch/OrganizationFolderEmptyView/main.jelly
@@ -43,7 +43,7 @@
           <a href="./configure" class="content-block__link">
             <span>Configure the project</span>
             <span class="trailing-icon">
-              <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px" />
+              <l:icon class="icon-sm" src="symbol-arrow-forward-outline plugin-ionicons-api" />
             </span>
           </a>
         </li>
@@ -51,7 +51,7 @@
           <a href="./computation" class="content-block__link">
             <span>Re-run the Folder Computation</span>
             <span class="trailing-icon">
-              <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-navigation-symbol.svg#ic_arrow_forward_24px" />
+              <l:icon class="icon-sm" src="symbol-arrow-forward-outline plugin-ionicons-api" />
             </span>
           </a>
         </li>


### PR DESCRIPTION
The change proposed adapts the standard Jenkins icons (ionicons) used in core itself. In this case, the icons look most the same, but ionicons support our theme-ability API and are recommended to use.