### PR TITLE
Make `NoTriggerBranchPropertyTest` pass against 2.446

### DIFF
--- a/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
@@ -187,7 +187,7 @@ public class NoTriggerBranchPropertyTest {
         property.setStrategy(strategy);
         branchSource.setStrategy(new DefaultBranchPropertyStrategy(new BranchProperty[] {property}));
         project.getSourcesList().add(branchSource);
-        r.configRoundtrip(project);
+        project.scheduleBuild2(0).getFuture().get();
         return new ProjectWrapper(r, project, controller, repositoryName);
     }
 


### PR DESCRIPTION
A couple of other places in this test (introduced in #244) were already using `Queue.Item.getFuture` but this one was using `JenkinsRule.configRoundtrip` which seems to have resulted in nondeterministic behavior: https://github.com/jenkinsci/jenkins/pull/8821#issuecomment-1961876826