### PR TITLE
Remove references to deprecated `ANTLRException`

### DIFF
--- a/src/main/java/jenkins/branch/OrganizationChildTriggersProperty.java
+++ b/src/main/java/jenkins/branch/OrganizationChildTriggersProperty.java
@@ -24,7 +24,6 @@
 
 package jenkins.branch;
 
-import antlr.ANTLRException;
 import com.cloudbees.hudson.plugins.folder.computed.PeriodicFolderTrigger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
@@ -95,11 +94,7 @@ public class OrganizationChildTriggersProperty extends OrganizationFolderPropert
      * @return a new default instance of this property.
      */
     public static OrganizationChildTriggersProperty newDefaultInstance() {
-        try {
-            return new OrganizationChildTriggersProperty(new PeriodicFolderTrigger("1d"));
-        } catch (ANTLRException e) {
-            throw new IllegalStateException(e);
-        }
+        return new OrganizationChildTriggersProperty(new PeriodicFolderTrigger("1d"));
     }
 
     /**

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -24,7 +24,6 @@
 
 package jenkins.branch;
 
-import antlr.ANTLRException;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderDescriptor;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.ChildNameGenerator;
@@ -204,11 +203,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
             }
         }
 
-        try {
-            addTrigger(new PeriodicFolderTrigger("1d"));
-        } catch (ANTLRException x) {
-            throw new IllegalStateException(x);
-        }
+        addTrigger(new PeriodicFolderTrigger("1d"));
         try {
             addProperty(OrganizationChildTriggersProperty.newDefaultInstance());
             addProperty(OrganizationChildOrphanedItemsProperty.newDefaultInstance());


### PR DESCRIPTION
This now throws `IllegalArgumentException` in Jenkins core, so no need for an explicit catch.