### PR TITLE
Deprecating `BranchProperty`s which do not work with Pipeline

### DIFF
--- a/src/main/java/jenkins/branch/BuildRetentionBranchProperty.java
+++ b/src/main/java/jenkins/branch/BuildRetentionBranchProperty.java
@@ -15,8 +15,9 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 /**
- * @author Stephen Connolly
+ * @deprecated Suppressed by {@code JobPropertyStep.HideSuperfluousBranchProperties} for Pipeline.
  */
+@Deprecated
 public class BuildRetentionBranchProperty extends BranchProperty {
 
     private final BuildDiscarder buildDiscarder;

--- a/src/main/java/jenkins/branch/RateLimitBranchProperty.java
+++ b/src/main/java/jenkins/branch/RateLimitBranchProperty.java
@@ -53,9 +53,9 @@ import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * A branch property that limits how often a specific branch can be built.
- *
- * @author Stephen Connolly
+ * @deprecated Suppressed by {@code JobPropertyStep.HideSuperfluousBranchProperties} for Pipeline.
  */
+@Deprecated
 @SuppressWarnings("unused") // instantiated by stapler
 public class RateLimitBranchProperty extends BranchProperty {
 

--- a/src/main/java/jenkins/branch/UntrustedBranchProperty.java
+++ b/src/main/java/jenkins/branch/UntrustedBranchProperty.java
@@ -62,9 +62,9 @@ import org.jvnet.tiger_types.Types;
  * locations</li>
  * </ul>
  *
- * @author Stephen Connolly
- * @author Kohsuke Kawaguchi
+ * @deprecated Not used by Pipeline.
  */
+@Deprecated
 public class UntrustedBranchProperty extends BranchProperty {
 
     private final Set<String> publisherWhitelist;


### PR DESCRIPTION
See https://github.com/jenkinsci/pipeline-plugin/pull/209. These would be used only by https://plugins.jenkins.io/multi-branch-project-plugin/ (deprecated), https://github.com/jenkinsci/freestyle-multibranch-plugin (not on UC), https://github.com/jenkinsci/literate-plugin (ditto), or https://github.com/jenkinsci/yaml-project-plugin (ditto).