### PR TITLE
Add displayName and description to PropertyMigration

### DIFF
--- a/src/main/java/jenkins/branch/PropertyMigration.java
+++ b/src/main/java/jenkins/branch/PropertyMigration.java
@@ -202,6 +202,11 @@ public abstract class PropertyMigration<F extends AbstractFolder<?>, P extends A
             return !missing.isEmpty();
         }
 
+        @Override
+        public String getDisplayName() {
+            return Messages.PropertyMigration_MonitorImpl_DisplayName();
+        }
+
         public List<PropertyMigration<?, ?>> getPending() {
             List<PropertyMigration<?, ?>> result = new ArrayList<>(missing.size());
             for (PropertyMigration<?, ?> m : missing) {

--- a/src/main/resources/jenkins/branch/Messages.properties
+++ b/src/main/resources/jenkins/branch/Messages.properties
@@ -31,6 +31,7 @@ NoTriggerBranchProperty.suppress_automatic_scm_triggering=Suppress automatic SCM
 NoTriggerProperty.strategy.indexing=For matching branches suppress builds triggered by indexing (continue to honor webhooks)
 NoTriggerProperty.strategy.events=For matching branches suppress builds triggered by webhooks (continue to trigger from indexing)
 NoTriggerProperty.strategy.none=For matching branches schedule all builds (nothing is suppressed)
+PropertyMigration.MonitorImpl.DisplayName=Folder Property Migration
 RateLimitBranchProperty.ApproxDaysBetweenBuilds=Approximately {0,choice,1\#a day|1<{0,number,integer} days} between builds
 RateLimitBranchProperty.ApproxHoursBetweenBuilds=Approximately {0,choice,1\#an hour|1<{0,number,integer} hours} between builds
 RateLimitBranchProperty.ApproxMinsBetweenBuilds=Approximately {0,choice,1\#a minute|1<{0,number,integer} minutes} between builds

--- a/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/description.jelly
+++ b/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    ${%blurb}
+</j:jelly>

--- a/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/description.properties
+++ b/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/description.properties
@@ -21,4 +21,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-blurb=Allows administrators to migrate folder properties.
+blurb=Allows administrators to migrate folder properties that have been deprecated in previous plugin releases.

--- a/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/description.properties
+++ b/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/description.properties
@@ -1,0 +1,24 @@
+#
+# The MIT License
+#
+# Copyright (c) 2018, CloudBees, Inc., Stephen Connolly.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+blurb=Allows administrators to migrate folder properties.


### PR DESCRIPTION
The UI of the administrative monitor for `PropertyMigration` seems to be broken since it is missing a display name:

![grafik](https://github.com/user-attachments/assets/ba4a2ae3-7444-4075-a825-771108395959)

This PR adds a display name and a descripton for the monitor:

![grafik](https://github.com/user-attachments/assets/9f3cfbf3-d35a-4c86-9ec5-55a853397dca)

I'd be happy to change the label / description to something more elaborate, suggestions are highly welcome.

### Testing done

Manually verified the UI looks as expected.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
