### PR TITLE
[JENKINS-73947] Improve CSP compatibility

### DIFF
--- a/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/branch-api-property-migration-disabled-form.js
+++ b/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/branch-api-property-migration-disabled-form.js
@@ -1,0 +1,7 @@
+window.addEventListener("DOMContentLoaded", function() {
+    const form = document.querySelector(".branch-api-property-migration-monitor-disabled-form");
+
+    form.addEventListener("submit", function(event) {
+        event.preventDefault();
+    });
+});

--- a/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/message.jelly
+++ b/src/main/resources/jenkins/branch/PropertyMigration/MonitorImpl/message.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <div class="alert alert-warning" role="alert">
     ${%blurb}
     <table width="100%" class="pane bigtable">
@@ -28,8 +28,9 @@
                 </div>
               </j:when>
               <j:otherwise>
+                <st:adjunct includes="jenkins.branch.PropertyMigration.MonitorImpl.branch-api-property-migration-disabled-form"/>
                 <form method="GET" action="${rootURL}/safeRestart" disabled="disabled"
-                      onsubmit="return false;"
+                      class="branch-api-property-migration-monitor-disabled-form"
                       style="float: none; display: inline; position: inherit;">
                   <span class="yui-button yui-link-button">
                     <span class="first-child">
@@ -65,7 +66,6 @@
                         enctype="multipart/form-data"
                         disabled="disabled"
                         action="${rootURL}/pluginManager/install"
-                        onsubmit="return addCrumb('install-${p.pluginName}');"
                         style="float: none; display: inline; position: inherit;">
                     <input type="hidden" name="plugin.${p.pluginName}.default" checked="true"/>
                     <span class="yui-button yui-link-button" name="dynamicLoad">
@@ -94,7 +94,6 @@
                         method="POST"
                         enctype="multipart/form-data"
                         action="${rootURL}/pluginManager/install"
-                        onsubmit="return addCrumb('install-${p.pluginName}');"
                         style="float: none; display: inline; position: inherit;">
                     <input type="hidden" name="${p.pluginInstallId}" checked="true"/>
                     <span class="yui-button yui-link-button primary" name="${p.pluginUpgrade?'Submit':'dynamicLoad'}">


### PR DESCRIPTION
* remove redundant inline event handlers in MonitorImpl/message.jelly
* extract inline event handler from MonitorImpl/message.jelly to a separate JavaScript file

<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-73947

### Testing done
Used the following script from JIRA to make the administrative monitor appear:
```groovy
import hudson.model.AdministrativeMonitor
import jenkins.branch.PropertyMigration.MonitorImpl
import jenkins.branch.NoTriggerOrganizationFolderProperty

def monitor = ExtensionList.lookup(AdministrativeMonitor.class).get(MonitorImpl.class)
monitor.add(new NoTriggerOrganizationFolderProperty.PropertyMigrationImpl())
```

https://www.loom.com/share/6ffffdf055be48a7bee6a0fe3c74aeda

https://www.loom.com/share/41c42ef5a87743fba81bb86c9e59bf73

Regarding the removal of `addCrumb` calls. I might be missing the point. I can't find any traces of such method ([trivial org search](https://github.com/search?q=org%3Ajenkinsci+addCrumb&type=code) doesn't fetch any results).
[This part of core](https://github.com/jenkinsci/jenkins/blame/d0c0d07bc4644bc7045ac321472d0a9822dbb8b8/war/src/main/webapp/scripts/hudson-behavior.js#L1450-L1474) has been there for a while, so I'm not sure what that inline extra call is supposed to do. Without it plugin can be installed just fine as you can see on the screen recording.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
