### PR TITLE
[JENKINS-74783] Fix job name line break behavior in Firefox

### DIFF
--- a/src/main/resources/jenkins/branch/ItemColumn/column.jelly
+++ b/src/main/resources/jenkins/branch/ItemColumn/column.jelly
@@ -28,7 +28,9 @@ THE SOFTWARE.
   <d:taglib uri="local">
     <d:tag name="link">
       <a href="${jobBaseUrl}${job.shortUrl}" class='model-link jenkins-table__link'>
-        <l:breakable value="${h.getRelativeDisplayNameFrom(job, itemGroup)}"/>
+        <span>
+          <l:breakable value="${h.getRelativeDisplayNameFrom(job, itemGroup)}"/>
+        </span>
       </a>
     </d:tag>
   </d:taglib>


### PR DESCRIPTION
#476 evidently was not tested in Firefox, which has awkward line break behavior with an `inline-flex`. https://ci.jenkins.io/job/Core/job/jenkins/view/change-requests/ looks like this:

> <img width="720" alt="Screenshot 2024-10-28 at 18 03 27" src="https://github.com/user-attachments/assets/a82e9b74-b03f-4cac-9991-9ef744c9785c">

This changes the column to be more consistent with https://github.com/jenkinsci/jenkins/blob/e1f99468fd81d6aa52dc434fefc6e0420e1cb449/core/src/main/resources/hudson/views/JobColumn/column.jelly#L29.

Tested only with browser dev tools in Firefox so far.

Lazy branch, please delete on merge if GH doesn't do it.