### PR TITLE
[JENKINS-74777] Improve locking around `jenkins.branch.MultiBranchProject#getProjectFactory`

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -160,7 +160,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     /**
      * The factory for building child job instances.
      */
-    private BranchProjectFactory<P, R> factory;
+    private volatile BranchProjectFactory<P, R> factory;
 
     private transient String srcDigest, facDigest;
 
@@ -339,11 +339,18 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
      * @return the {@link BranchProjectFactory}.
      */
     @NonNull
-    public synchronized BranchProjectFactory<P, R> getProjectFactory() {
-        if (factory == null) {
-            setProjectFactory(newProjectFactory());
+    public BranchProjectFactory<P, R> getProjectFactory() {
+        BranchProjectFactory<P, R> value = factory;
+        if (value == null) {
+            synchronized (this) {
+                value = factory;
+                if (value == null) {
+                    value = newProjectFactory();
+                    setProjectFactory(value);
+                }
+            }
         }
-        return factory;
+        return value;
     }
 
     /**

--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -339,6 +339,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
      * @return the {@link BranchProjectFactory}.
      */
     @NonNull
+    @SuppressFBWarnings(value = "UG_SYNC_SET_UNSYNC_GET", justification = "False positive: synchronization is handled via double-checked locking")
     public BranchProjectFactory<P, R> getProjectFactory() {
         BranchProjectFactory<P, R> value = factory;
         if (value == null) {


### PR DESCRIPTION
### Problem

See [JENKINS-74777](https://issues.jenkins.io/browse/JENKINS-74777).

### Solution

As described in the above ticket, use double-checked locking.

### Implementation

As in [this page](https://errorprone.info/bugpattern/DoubleCheckedLocking).

<!-- Please describe your pull request here. -->

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
