### PR TITLE
[JENKINS-74975] Fix Semaphore over-allocation of permits / limit all CleanupTasks

### DIFF
--- a/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
+++ b/src/main/java/jenkins/branch/WorkspaceLocatorImpl.java
@@ -66,6 +66,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.Jenkins;
@@ -395,9 +397,9 @@ public class WorkspaceLocatorImpl extends WorkspaceLocator {
             }
             TopLevelItem tli = (TopLevelItem) item;
             Jenkins jenkins = Jenkins.get();
-            Computer.threadPoolForRemoting.submit(new CleanupTask(tli, jenkins));
             // Starts provisioner Thread which is tasked with starting cleanup Threads
-            new CleanupTaskProvisioner(tli, jenkins.getNodes()).run();
+            new CleanupTaskProvisioner(tli,
+                Stream.concat(Stream.of(jenkins), jenkins.getNodes().stream()).collect(Collectors.toList())).run();
         }
 
         @Override


### PR DESCRIPTION
(amends https://github.com/jenkinsci/branch-api-plugin/pull/237)

The `CleanupTask` of the built-in node were scheduled instantly without acquiring permit from the Semaphore but they were releasing permits, hence creating additional permits over time. Reducing the effectiveness of the limit overtime.

Add the Jenkins `built-in` node to list of nodes to be limited.

NOTES: I guess another solution is to continue not limit the number of `CleanupTask` executed for the `built-in` node but that  looks rather confusing in the first place to have a `CLEANUP_THREAD_LIMIT` that only partially limit the Cleanup tasks..

### Testing done

* Create a Jenkins instance with `-Djenkins.branch.WorkspaceLocatorImpl\$Deleter.CLEANUP_THREAD_LIMIT=1`
* In **Manage Jenkins > Script Console**, execute `jenkins.branch.WorkspaceLocatorImpl.Deleter.cleanupPool.availablePermits()` and validate that it shows `1`
* Create a Multibranch pipeline with at least one branch
* Add a filter to have all branches discarded and removed by the orphaned item strategy and save
* In **Manage Jenkins > Script Console**, execute `jenkins.branch.WorkspaceLocatorImpl.Deleter.cleanupPool.availablePermits()` and validate that it still shows `1`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue