### PR TITLE
[JENKINS-74879] Use strikethrough on merged pull request name column

### DIFF
--- a/src/main/resources/jenkins/branch/ItemColumn/column.jelly
+++ b/src/main/resources/jenkins/branch/ItemColumn/column.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <d:taglib uri="local">
     <d:tag name="link">
-      <a href="${jobBaseUrl}${job.shortUrl}" class='model-link jenkins-table__link'>
+      <a href="${jobBaseUrl}${job.shortUrl}" class='model-link'>
         <span>
           <l:breakable value="${h.getRelativeDisplayNameFrom(job, itemGroup)}"/>
         </span>


### PR DESCRIPTION
## [JENKINS-74879] Use strikethrough on merged pull request name column

[JENKINS-74879](https://issues.jenkins.io/browse/JENKINS-74879) reports that the strikethrough text is no longer displayed when a pull request has been merged or closed.  The strikethrough text is a nice visual indicator that the job is no longer active.  Let's bring it back so that the visual hint is still there for users.

The strikethrough text is displayed on the job page, but not in the table of jobs for each pull request or branch.

Change was originally introduced when pull request titles were enabled by default in the column name.  Refer to:

* https://github.com/jenkinsci/branch-api-plugin/pull/476

Assumed that it is better to drop the jenkins-table__link formatting in the plugin rather than adjust the CSS definion in Jenkins core.  That CSS definition has been in place in Jenkins core since Sep 2022 and likely would have unexpected side effects if changed in core.  Refer to:

* https://github.com/jenkinsci/jenkins/pull/6248

### Before this change

![s-tag-does-not-change-text](https://github.com/user-attachments/assets/1a322620-e7c4-43c0-85c1-6330cd13ac76)

### After this change

![s-tag-changes-text](https://github.com/user-attachments/assets/a75b2011-ea7b-45d8-be83-4570e192386e)

### Testing done

* Confirmed that the link has strikethrough text with this change.
* Confirmed that the non-striketrhrough link still looks good

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
