### PR TITLE
Prepare for removal of `recordLegacyName`

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProjectDescriptor.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectDescriptor.java
@@ -264,7 +264,7 @@ public abstract class MultiBranchProjectDescriptor extends AbstractFolderDescrip
             return NameMangler.apply(NameEncoder.decode(legacyDirName));
         }
 
-        @Override
+        // TODO remove after it is removed in cloudbees-folder
         public void recordLegacyName(MultiBranchProject<P, R> parent, P item, String legacyDirName) throws IOException {
             // no-op because we already tracked the name in Branch.getName()
         }

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -885,7 +885,7 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
             return NameMangler.apply(NameEncoder.decode(legacyDirName));
         }
 
-        @Override
+        // TODO remove after it is removed in cloudbees-folder
         public void recordLegacyName(OrganizationFolder parent, MultiBranchProject<?, ?> item, String legacyDirName)
                 throws IOException {
             item.addProperty(new ProjectNameProperty(legacyDirName));


### PR DESCRIPTION
`recordLegacyName` is no longer called from `cloudbees-folder`, so we would like to eventually remove the method there. To do that, first remove the `@Override` annotation here so that we stop depending on the interface declaration in `cloudbees-folder`. Once we feel confident enough that we no longer need to support older versions of `branch-api` from recent versions of `cloudbees-folder`, we can then remove the method there, and once that change propagates here we can then delete the method here.

### Testing done

CI build

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
