### PR TITLE
Prepare to eventually remove `ChildNameGenerator.CHILD_NAME_FILE`

### DIFF
--- a/src/test/java/integration/MigrationTest.java
+++ b/src/test/java/integration/MigrationTest.java
@@ -25,13 +25,10 @@
 
 package integration;
 
-import com.cloudbees.hudson.plugins.folder.ChildNameGenerator;
 import hudson.model.Job;
 import hudson.model.TopLevelItem;
 import integration.harness.BasicMultiBranchProjectFactory;
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +39,6 @@ import jenkins.branch.OrganizationFolder;
 import jenkins.scm.impl.mock.MockSCMController;
 import jenkins.scm.impl.mock.MockSCMDiscoverBranches;
 import jenkins.scm.impl.mock.MockSCMNavigator;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.junit.AfterClass;
@@ -54,7 +50,6 @@ import org.jvnet.hudson.test.JenkinsSessionRule;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class MigrationTest {
@@ -228,13 +223,7 @@ public class MigrationTest {
                 jobByName.put(j.getFullName(), j);
                 jobByDirName.put(jobDirName, j);
                 jobByDisplayName.put(j.getFullDisplayName(), j);
-                File nameFile = new File(j.getRootDir(), ChildNameGenerator.CHILD_NAME_FILE);
-                assertThat("Exists: " + nameFile, nameFile.isFile(), is(true));
-                assertThat("Contents: " + nameFile, FileUtils.readFileToString(nameFile, StandardCharsets.UTF_8), is(j.getName()));
             }
-            File nameFile = new File(p.getRootDir(), ChildNameGenerator.CHILD_NAME_FILE);
-            assertThat("Exists: " + nameFile, nameFile.isFile(), is(true));
-            assertThat("Contents: " + nameFile, FileUtils.readFileToString(nameFile, StandardCharsets.UTF_8), is(p.getName()));
         }
         assertThat("Display Names are repo names", byDisplayName.keySet(), containsInAnyOrder(
                 "test.example.com",


### PR DESCRIPTION
Prerequisite to https://github.com/jenkinsci/cloudbees-folder-plugin/pull/483. That PR intends to eventually remove `ChildNameGenerator.CHILD_NAME_FILE`, but before we can do that, we have to remove any test assertions that expect it to be present.

### Testing done

- `mvn clean verify` with this PR and without https://github.com/jenkinsci/cloudbees-folder-plugin/pull/483
- `mvn clean verify` without this PR and with https://github.com/jenkinsci/cloudbees-folder-plugin/pull/483 (failed as expected)
- `mvn clean verify` with this PR and with https://github.com/jenkinsci/cloudbees-folder-plugin/pull/483 (passed as expected)

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
