### PR TITLE
Add a BaseView to ensure DefaultViewsTabBar is used

### DIFF
--- a/src/main/java/jenkins/branch/BaseView.java
+++ b/src/main/java/jenkins/branch/BaseView.java
@@ -1,0 +1,65 @@
+package jenkins.branch;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.ListView;
+import hudson.model.View;
+import hudson.model.ViewGroup;
+import hudson.security.ACL;
+import hudson.security.Permission;
+import java.io.IOException;
+import jenkins.scm.api.SCMCategory;
+import org.springframework.security.core.Authentication;
+
+public abstract class BaseView<T extends SCMCategory<?>> extends ListView {
+
+    protected final T category;
+
+    public BaseView(ViewGroup owner, @NonNull T category) {
+        super(category.getName(), owner);
+        this.category = category;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDisplayName() {
+        return category.getDisplayName() + " (" + getItems().size() + ")";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRecurse() {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public ACL getACL() {
+        final ACL acl = super.getACL();
+        return new ACL() {
+            @Override
+            public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
+                if (View.CREATE.equals(permission)
+                        || View.CONFIGURE.equals(permission)
+                        || View.DELETE.equals(permission)) {
+                    return false;
+                }
+                return acl.hasPermission2(a, permission);
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void save() throws IOException {
+        // no-op
+    }
+}

--- a/src/main/java/jenkins/branch/BaseView.java
+++ b/src/main/java/jenkins/branch/BaseView.java
@@ -8,11 +8,14 @@ import hudson.security.ACL;
 import hudson.security.Permission;
 import java.io.IOException;
 import jenkins.scm.api.SCMCategory;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.security.core.Authentication;
 
+@Restricted(NoExternalUse.class)
 public abstract class BaseView<T extends SCMCategory<?>> extends ListView {
 
-    protected final T category;
+    private final T category;
 
     public BaseView(ViewGroup owner, @NonNull T category) {
         super(category.getName(), owner);

--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -199,13 +199,7 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
      * A custom category specific view.
      */
     @Restricted(NoExternalUse.class)
-    public static class ViewImpl extends ListView {
-
-        /**
-         * The category that this view selects.
-         */
-        @NonNull
-        private final SCMHeadCategory category;
+    public static class ViewImpl extends BaseView<SCMHeadCategory> {
 
         /**
          * Creates a new view.
@@ -214,10 +208,9 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
          * @param category the category.
          */
         public ViewImpl(ViewGroup owner, @NonNull SCMHeadCategory category) {
-            super(category.getName(), owner);
-            this.category = category;
+            super(owner,category);
             try {
-                getJobFilters().replaceBy(Collections.singletonList(new BranchCategoryFilter(category)));
+                getJobFilters().replaceBy(List.of(new BranchCategoryFilter(category)));
                 DescribableList<ListViewColumn, Descriptor<ListViewColumn>> columns = getColumns();
                 columns.replace(columns.get(StatusColumn.class), new BranchStatusColumn());
                 columns.replace(columns.get(JobColumn.class), new ItemColumn());
@@ -225,50 +218,6 @@ public class MultiBranchProjectViewHolder extends AbstractFolderViewHolder {
                 // ignore
             }
             setRecurse(false);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDisplayName() {
-            return category.getDisplayName() + " (" + getItems().size() + ")";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean isRecurse() {
-            return false;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public ACL getACL() {
-            final ACL acl = super.getACL();
-            return new ACL() {
-                @Override
-                public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
-                    if (View.CREATE.equals(permission)
-                            || View.CONFIGURE.equals(permission)
-                            || View.DELETE.equals(permission)) {
-                        return false;
-                    }
-                    return acl.hasPermission2(a, permission);
-                }
-            };
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void save() throws IOException {
-            // no-op
         }
 
         /**

--- a/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
+++ b/src/main/java/jenkins/branch/MultiBranchProjectViewHolder.java
@@ -28,12 +28,9 @@ import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
-import hudson.model.ListView;
 import hudson.model.View;
 import hudson.model.ViewDescriptor;
 import hudson.model.ViewGroup;
-import hudson.security.ACL;
-import hudson.security.Permission;
 import hudson.util.DescribableList;
 import hudson.views.DefaultViewsTabBar;
 import hudson.views.JobColumn;
@@ -49,7 +46,6 @@ import jenkins.scm.api.SCMHeadCategory;
 import net.jcip.annotations.GuardedBy;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.springframework.security.core.Authentication;
 
 /**
  * Holds the view configuration for an {@link MultiBranchProject}.

--- a/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
@@ -27,12 +27,9 @@ package jenkins.branch;
 import com.cloudbees.hudson.plugins.folder.views.AbstractFolderViewHolder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
-import hudson.model.ListView;
 import hudson.model.View;
 import hudson.model.ViewDescriptor;
 import hudson.model.ViewGroup;
-import hudson.security.ACL;
-import hudson.security.Permission;
 import hudson.views.DefaultViewsTabBar;
 import hudson.views.StatusColumn;
 import hudson.views.ViewsTabBar;
@@ -45,7 +42,6 @@ import jenkins.scm.api.SCMSourceCategory;
 import net.jcip.annotations.GuardedBy;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.springframework.security.core.Authentication;
 
 import static java.util.Arrays.asList;
 

--- a/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolderViewHolder.java
@@ -189,13 +189,7 @@ public class OrganizationFolderViewHolder extends AbstractFolderViewHolder {
      * A custom category specific view.
      */
     @Restricted(NoExternalUse.class)
-    public static class ViewImpl extends ListView {
-
-        /**
-         * The category that this view selects.
-         */
-        @NonNull
-        private final SCMSourceCategory category;
+    public static class ViewImpl extends BaseView<SCMSourceCategory> {
 
         /**
          * Creates a new view.
@@ -204,10 +198,9 @@ public class OrganizationFolderViewHolder extends AbstractFolderViewHolder {
          * @param category the category.
          */
         public ViewImpl(ViewGroup owner, @NonNull SCMSourceCategory category) {
-            super(category.getName(), owner);
-            this.category = category;
+            super(owner,category);
             try {
-                getJobFilters().replaceBy(asList(new MultiBranchCategoryFilter(category)));
+                getJobFilters().replaceBy(List.of(new MultiBranchCategoryFilter(category)));
                 getColumns().replaceBy(asList(
                         new StatusColumn(),
                         new WeatherColumn(),
@@ -218,50 +211,6 @@ public class OrganizationFolderViewHolder extends AbstractFolderViewHolder {
                 // ignore
             }
             setRecurse(false);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getDisplayName() {
-            return category.getDisplayName() + " (" + getItems().size() + ")";
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean isRecurse() {
-            return false;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public ACL getACL() {
-            final ACL acl = super.getACL();
-            return new ACL() {
-                @Override
-                public boolean hasPermission2(@NonNull Authentication a, @NonNull Permission permission) {
-                    if (View.CREATE.equals(permission)
-                            || View.CONFIGURE.equals(permission)
-                            || View.DELETE.equals(permission)) {
-                        return false;
-                    }
-                    return acl.hasPermission2(a, permission);
-                }
-            };
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void save() throws IOException {
-            // no-op
         }
 
         /**

--- a/src/main/resources/jenkins/branch/BaseView/main.jelly
+++ b/src/main/resources/jenkins/branch/BaseView/main.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
+  <j:set var="views" value="${it.owner.views}"/>
+  <j:set var="currentView" value="${it}"/>
+  <j:if test="${items.isEmpty()}">
+    <st:include it="${it.owner.viewsTabBar}" page="viewTabs"/>
+    <st:include it="${it}" page="noJob.jelly"/>
+  </j:if>
+  <j:if test="${!items.isEmpty()}">
+    <t:projectView jobs="${items}" showViewTabs="true" columnExtensions="${it.columns}" indenter="${it.indenter}" itemGroup="${it.owner.itemGroup}">
+      <st:include it="${it.owner.viewsTabBar}" page="viewTabs"/>
+    </t:projectView>
+  </j:if>
+</j:jelly>


### PR DESCRIPTION
With https://github.com/jenkinsci/jenkins/pull/10379 (available in 2.513) it is possible for users to define a default views tabbar. When a user chooses a different implementation e.g. from favorite-views plugin, this affects also the views in org and multibranch jobs as they use the ListView from core.

This change introduces a BaseView that brings its own main.jelly ensuring the viewstabbar from the corresponding viewholder is used. The BaseView also unifies the almost identical view implementations.

<!-- Please describe your pull request here. -->

### Testing done
Verified that with Jenkins 2.513 and favorite-views plugin installed and set as user default, the views tabbar for org or mutlibranch jobs is still the DefaultViewsTabBar.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
