### PR TITLE
[JENKINS-75586] Add configurable maximum concurrent indexing limit

### DIFF
--- a/src/main/resources/jenkins/branch/Messages.properties
+++ b/src/main/resources/jenkins/branch/Messages.properties
@@ -48,6 +48,7 @@ RateLimitBranchProperty.duration.month=Month
 RateLimitBranchProperty.duration.year=Year
 MultiBranchProject.BranchIndexing.displayName=Scan {0}
 MultiBranchProject.CopyItemVeto.reason=Copying branch projects outside of their multi-branch container is not supported.
+MultiBranchProject.MaxConcurrentIndexing=Already indexing maximum number of projects (limit: {0})
 MultiBranchProjectDisplayNamingTrait.DisplayName=Job display name with fallback to name
 MultiBranchProjectDisplayNamingTrait.Raw=Simple name only
 MultiBranchProjectDisplayNamingTrait.RawAndDisplayName=Name and, if available, display name


### PR DESCRIPTION
- Add system property `jenkins.branch.MultiBranchProject.maxConcurrentIndexing` to configure the maximum
  number of concurrent indexing operations
  - Default value remains 5 to maintain backward compatibility
  - Override `getCauseOfBlockage()` to check against configurable limit
  - Add `indexingCount()` method to count actively indexing projects
  - Add user-friendly message when limit is reached

  Users can configure via:
  -Djenkins.branch.MultiBranchProject.maxConcurrentIndexing=

  ### Testing done

  - Manually tested with different values of the system property (3, 5, 10)
  - Verified that indexing is blocked when the limit is reached
  - Confirmed that the appropriate message is displayed when indexing is blocked
  - Tested that default behavior (limit of 5) is maintained when property is not set
  - Verified backward compatibility with existing configurations

  ### Submitter checklist
  - [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main
  branch!
  - [x] Ensure that the pull request title represents the desired changelog entry
  - [x] Please describe what you did
  - [x] Link to relevant issues in GitHub or Jira -
  [JENKINS-75586](https://issues.jenkins.io/browse/JENKINS-75586)
  - [ ] Link to relevant pull requests, esp. upstream and downstream changes
  - [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed