### PR TITLE
Add detail for branch indexing cause

### DIFF
--- a/src/main/resources/jenkins/branch/BranchIndexingCause/detail.jelly
+++ b/src/main/resources/jenkins/branch/BranchIndexingCause/detail.jelly
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2025 Jan Faracik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+    <j:set var="url" value="${it.indexingUrl}"/>
+    <j:choose>
+        <j:when test="${url != null}">
+            <a href="${rootURL}/${url}console"
+               class="jenkins-details__item">
+                <div class="jenkins-details__item__icon">
+                    <l:icon src="symbol-cause" />
+                </div>
+                <div>
+                    ${%Started by branch indexing}
+                </div>
+            </a>
+        </j:when>
+        <j:otherwise>
+            <div class="jenkins-details__item">
+                <div class="jenkins-details__item__icon">
+                    <l:icon src="symbol-cause" />
+                </div>
+                <div>
+                    ${%Started by branch indexing}
+                </div>
+            </div>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>


### PR DESCRIPTION
Relates to https://github.com/jenkinsci/jenkins/pull/11128

This PR adds a 'detail' to the experimental run UI, showing the cause of the run in the details row.

<img width="587" height="97" alt="image" src="https://github.com/user-attachments/assets/a56d94f9-fab5-4928-a7da-49595a42c4fc" />

### Testing done

* Appears as expected

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
