### PR TITLE
[JENKINS-76325] Organization Folder: Support creating multiple projects from a single repository based on multiple Jenkinsfile paths

### DIFF
--- a/src/main/java/jenkins/branch/MultiBranchProject.java
+++ b/src/main/java/jenkins/branch/MultiBranchProject.java
@@ -689,6 +689,43 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
                 }
             }
             for (final SCMSource source : scmSources) {
+                String scriptPathFetched = "";
+                try {
+                    scriptPathFetched = (String) _factory.getClass().getMethod("getScriptPath").invoke(_factory);
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "getScriptPath error: {0}", e.getMessage());
+                }
+
+                if (scriptPathFetched != null && scriptPathFetched != "") {
+                    final String scriptPath = scriptPathFetched;
+                    LOGGER.log(Level.INFO, "scriptPath: {0}", scriptPath);
+                    try {
+                        SCMSourceCriteria criteria = (probe, l) -> {
+                            boolean exists = probe.stat(scriptPath).exists();
+                            if (exists) {
+                                l.getLogger().format("      '%s' found%n", scriptPath);
+                            } else {
+                                l.getLogger().format("      '%s' not found%n", scriptPath);
+                            }
+
+                            return exists;
+                        };
+
+                        source.fetch(criteria, new SCMHeadObserverImpl(source, observer, listener, _factory,
+                                new IndexingCauseFactory(), null), listener);
+
+                        observer.observed().forEach((branchName) -> {
+                            LOGGER.log(Level.INFO, "Observed scriptPath: {0}, branch: {1}",
+                                    new Object[]{scriptPath, branchName});
+                        });
+                    } catch (IOException | InterruptedException | RuntimeException e) {
+                        listener.error("[%tc] Could not fetch branches from source %s",
+                                System.currentTimeMillis(), source.getId());
+                        throw e;
+                    }
+                    continue;
+                }
+
                 try {
                     source.fetch(new SCMHeadObserverImpl(source, observer, listener, _factory,
                         new IndexingCauseFactory(), null), listener);
@@ -2360,7 +2397,7 @@ public abstract class MultiBranchProject<P extends Job<P, R> & TopLevelItem,
     }
 
     /**
-     * Adds the {@link MultiBranchProject.State#sourceActions} to
+     * Adds the {@link State#sourceActions} to
      * {@link MultiBranchProject#getAllActions()}.
      *
      * @since 2.0

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -1450,8 +1450,8 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                         Matcher matcher = pattern.matcher(scriptPath);
                                         if (matcher.matches()) {
                                             newProjectName = projectName + matcher.group(1);
+                                            LOGGER.info("newProjectName: " + newProjectName);
                                         }
-                                        LOGGER.info("newProjectName: " + newProjectName);
                                     } catch (Exception e) {
                                         LOGGER.warning(() -> "Failed to get new project name from " + candidateFactory + ": " + e.getMessage());
                                         continue;
@@ -1497,8 +1497,8 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                         if (property == null || !newProjectName.equals(property.getName())) {
                             existing.getProperties().remove(ProjectNameProperty.class);
                             existing.addProperty(new ProjectNameProperty(newProjectName));
-                            existing.setDisplayName(newProjectName);
                         }
+                        existing.setDisplayName(newProjectName);
                         for (AbstractFolderProperty<?> folderProperty : getProperties()) {
                             if (folderProperty instanceof OrganizationFolderProperty) {
                                 ((OrganizationFolderProperty) folderProperty).applyDecoration(existing,

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -1442,16 +1442,20 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                             LOGGER.fine(() -> candidateFactory + " recognizes " + projectName + " with " + attributes + "? " + recognizes);
                             if (recognizes) {
                                 newProjectName = projectName;
-
                                 if (createMultipleProjects && projectNamePatten != null && !projectNamePatten.isEmpty()) {
-                                    String scriptPath = (String) candidateFactory.getClass().getMethod("getScriptPath").invoke(candidateFactory);
-                                    LOGGER.info(() -> "scriptPath: " + scriptPath);
-                                    Pattern pattern = Pattern.compile(projectNamePatten);
-                                    Matcher matcher = pattern.matcher(scriptPath);
-                                    if (matcher.matches()) {
-                                        newProjectName = projectName + matcher.group(1);
+                                    try {
+                                        String scriptPath = (String) candidateFactory.getClass().getMethod("getScriptPath").invoke(candidateFactory);
+                                        LOGGER.info("scriptPath: " + scriptPath);
+                                        Pattern pattern = Pattern.compile(projectNamePatten);
+                                        Matcher matcher = pattern.matcher(scriptPath);
+                                        if (matcher.matches()) {
+                                            newProjectName = projectName + matcher.group(1);
+                                        }
+                                        LOGGER.info("newProjectName: " + newProjectName);
+                                    } catch (Exception e) {
+                                        LOGGER.warning(() -> "Failed to get new project name from " + candidateFactory + ": " + e.getMessage());
+                                        continue;
                                     }
-                                    LOGGER.info("newProjectName: " + newProjectName);
                                 }
 
                                 String folderName = NameEncoder.encode(newProjectName);

--- a/src/main/java/jenkins/branch/OrganizationFolder.java
+++ b/src/main/java/jenkins/branch/OrganizationFolder.java
@@ -1450,7 +1450,6 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                         Matcher matcher = pattern.matcher(scriptPath);
                                         if (matcher.matches()) {
                                             newProjectName = projectName + matcher.group(1);
-                                            LOGGER.info("newProjectName: " + newProjectName);
                                         }
                                     } catch (Exception e) {
                                         LOGGER.warning(() -> "Failed to get new project name from " + candidateFactory + ": " + e.getMessage());
@@ -1467,8 +1466,10 @@ public final class OrganizationFolder extends ComputedFolder<MultiBranchProject<
                                 existing = observer.shouldUpdate(folderName);
                                 try {
                                     if (existing != null) {
+                                        LOGGER.info("Update existing project: " + folderName);
                                         completeExisting(candidateFactory, attributes, existing, wasBuildable, wasDisabled);
                                     } else {
+                                        LOGGER.info("Create new project: " + folderName);
                                         completeNew(candidateFactory, attributes, folderName);
                                     }
                                 } finally {

--- a/src/main/resources/jenkins/branch/OrganizationFolder/configure-entries.jelly
+++ b/src/main/resources/jenkins/branch/OrganizationFolder/configure-entries.jelly
@@ -28,6 +28,14 @@
     <f:entry field="navigators" title="${%Repository Sources}">
       <f:repeatableHeteroProperty field="navigators" hasHeader="true"/>
     </f:entry>
+
+    <f:entry field="createMultipleProjects" title="${%CreateMultipleProjects.DisplayName}">
+      <f:checkbox default="false" title="${%CreateMultipleProjects.Description}"/>
+      <f:entry field="projectNamePattern" title="${%ProjectNamePattern.DisplayName}">
+          <f:textbox default=".*?(-[^.]+).*"/>
+      </f:entry>
+    </f:entry>
+
     <f:entry field="projectFactories" title="${%Project Recognizers}">
       <f:repeatableHeteroProperty field="projectFactories" hasHeader="true" />
     </f:entry>

--- a/src/main/resources/jenkins/branch/OrganizationFolder/configure-entries.properties
+++ b/src/main/resources/jenkins/branch/OrganizationFolder/configure-entries.properties
@@ -1,0 +1,5 @@
+CreateMultipleProjects.DisplayName=Create Multiple Projects
+CreateMultipleProjects.Description=Enable multiple projects creation of the same repository based on Jenkinsfile path pattern
+
+ProjectNamePattern.DisplayName=Project Name Pattern
+ProjectNamePattern.Description=Regular expression pattern to extract project name suffix from Jenkinsfile path. Default pattern extracts suffix after last hyphen (e.g., 'Jenkinsfile-win' creates 'myproject-win')

--- a/src/main/resources/jenkins/branch/OrganizationFolder/help-createMultipleProjects.html
+++ b/src/main/resources/jenkins/branch/OrganizationFolder/help-createMultipleProjects.html
@@ -1,0 +1,26 @@
+<div>
+  Controls whether to create multiple projects of the same repository based on Jenkinsfile path patterns.
+  
+  <p>
+    When enabled, the system will examine Jenkinsfile paths and create separate projects
+    for different variants of the same repository based on the configured pattern.
+  </p>
+  
+  <h3>Example</h3>
+  <p>
+    If you have Jenkinsfiles like:
+    <ul>
+      <li><code>Jenkinsfile</code> (main build)</li>
+      <li><code>Jenkinsfile-win</code> (Windows-specific build)</li>
+      <li><code>Jenkinsfile-mac</code> (Mac-specific build)</li>
+    </ul>
+  </p>
+  <p>
+    With the default pattern <code>.*?(-[^.]+).*</code>, this would create:
+    <ul>
+      <li><code>myproject</code> from <code>Jenkinsfile</code></li>
+      <li><code>myproject-win</code> from <code>Jenkinsfile-win</code></li>
+      <li><code>myproject-mac</code> from <code>Jenkinsfile-mac</code></li>
+    </ul>
+  </p>
+</div>

--- a/src/main/resources/jenkins/branch/OrganizationFolder/help-projectNamePattern.html
+++ b/src/main/resources/jenkins/branch/OrganizationFolder/help-projectNamePattern.html
@@ -1,0 +1,37 @@
+<div>
+  Regular expression pattern used to extract project name suffix from Jenkinsfile path.
+  
+  <p>
+    The pattern is applied to the Jenkinsfile path, and the first capture group
+    (if any) is appended to the base repository name to create the final project name.
+  </p>
+  
+  <h3>Default Pattern</h3>
+  <p>
+    <code>.*?(-[^.]+).*</code>
+  </p>
+  <p>
+    This pattern captures everything after the last hyphen and before the final dot.
+  </p>
+  
+  <h3>Examples</h3>
+  <table border="1" cellpadding="3" cellspacing="0">
+    <tr><th>Pattern</th><th>Jenkinsfile</th><th>Resulting Project</th></tr>
+    <tr>
+      <td><code>.*?(-[^.]+).*</code></td>
+      <td><code>Jenkinsfile-win</code></td>
+      <td><code>myproject-win</code></td>
+    </tr>
+    <tr>
+      <td><code>.*?(-[^.]+).*</code></td>
+      <td><code>Jenkinsfile</code></td>
+      <td><code>myproject</code></td>
+    </tr>
+  </table>
+  
+  <h3>Pattern Tips</h3>
+  <ul>
+    <li>The first capture group's content is used as the suffix</li>
+    <li>If no match is found, the original repository name is used</li>
+  </ul>
+</div>

--- a/src/test/java/jenkins/branch/OrganizationFolderMultiProjectTest.java
+++ b/src/test/java/jenkins/branch/OrganizationFolderMultiProjectTest.java
@@ -1,0 +1,213 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Jenkins Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.branch;
+
+import jenkins.scm.impl.SingleSCMNavigator;
+import jenkins.scm.impl.SingleSCMSource;
+import jenkins.scm.impl.mock.MockSCM;
+import jenkins.scm.impl.mock.MockSCMController;
+import jenkins.scm.impl.mock.MockSCMHead;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import java.util.Collections;
+import static org.junit.Assert.*;
+
+public class OrganizationFolderMultiProjectTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    /**
+     * Tests that new configuration fields have correct default values.
+     * Verifies createMultipleProjects and projectNamePattern defaults.
+     */
+    @Test
+    public void testMultiProjectConfigurationDefaults() throws Exception {
+        OrganizationFolder folder = r.jenkins.createProject(OrganizationFolder.class, "top");
+
+        // Test default values
+        assertFalse("createMultipleProjects should default to false", folder.isCreateMultipleProjects());
+        assertEquals("Default project name pattern should be correct", ".*?(-[^.]+).*", folder.getProjectNamePattern());
+
+        // Test configuration round-trip
+        folder = r.configRoundtrip(folder);
+
+        assertFalse("createMultipleProjects should still be false after round-trip", folder.isCreateMultipleProjects());
+        assertEquals("Project name pattern should be preserved after round-trip", ".*?(-[^.]+).*", folder.getProjectNamePattern());
+    }
+
+    /**
+     * Tests setter methods for new configuration fields.
+     */
+    @Test
+    public void testMultiProjectConfigurationSetters() throws Exception {
+        OrganizationFolder folder = r.jenkins.createProject(OrganizationFolder.class, "top");
+
+        // Test setting values
+        folder.setCreateMultipleProjects(true);
+        folder.setProjectNamePattern(".*?-(dev|prod).*");
+
+        assertTrue("createMultipleProjects should be true after setting", folder.isCreateMultipleProjects());
+        assertEquals("Project name pattern should be updated", ".*?-(dev|prod).*", folder.getProjectNamePattern());
+
+        // Test null pattern handling
+        folder.setProjectNamePattern(null);
+        assertEquals("Null pattern should default to fallback", ".*?(-[^.]+).*", folder.getProjectNamePattern());
+    }
+
+    /**
+     * Tests configuration persistence through round-trip.
+     */
+    @Test
+    public void testMultiProjectFormSubmission() throws Exception {
+        OrganizationFolder folder = r.jenkins.createProject(OrganizationFolder.class, "top");
+
+        // Test through configuration round-trip with modified values
+        folder.setCreateMultipleProjects(true);
+        folder.setProjectNamePattern(".*?-(test|staging).*");
+
+        OrganizationFolder configured = r.configRoundtrip(folder);
+
+        assertTrue("createMultipleProjects should be true after configuration", configured.isCreateMultipleProjects());
+        assertEquals("Project name pattern should be saved correctly", ".*?-(test|staging).*", configured.getProjectNamePattern());
+    }
+
+    /**
+     * Tests project name extraction functionality when multiple projects are enabled.
+     */
+    @Test
+    public void testProjectNameExtractionWithMultipleProjects() throws Exception {
+        try (MockSCMController controller = MockSCMController.create()) {
+            // Create repository 
+            controller.createRepository("myproject");
+
+            OrganizationFolder folder = r.jenkins.createProject(OrganizationFolder.class, "test-org");
+            folder.setCreateMultipleProjects(true);
+            folder.setProjectNamePattern(".*?(-[^.]+).*");
+
+            // Add mock navigator and source
+            SingleSCMSource source = new SingleSCMSource("myproject-source",
+                    new MockSCM(controller, "myproject", new MockSCMHead("master"), null));
+            folder.getNavigators().add(new SingleSCMNavigator("myproject", Collections.singletonList(source)));
+
+            // Trigger scan
+            folder.scheduleBuild(0);
+            r.waitUntilNoActivity();
+
+            // Verify that organization folder processes the scan
+            assertNotNull("Organization folder should process scan", folder.getComputation());
+
+            // Test configuration values
+            assertTrue("createMultipleProjects should be true", folder.isCreateMultipleProjects());
+            assertEquals("Project name pattern should be set", ".*?(-[^.]+).*", folder.getProjectNamePattern());
+        }
+    }
+
+    /**
+     * Tests that configuration changes trigger rescans appropriately.
+     */
+    @Test
+    public void testConfigurationChangeTriggersRescan() throws Exception {
+        try (MockSCMController controller = MockSCMController.create()) {
+            controller.createRepository("test-repo");
+
+            OrganizationFolder folder = r.jenkins.createProject(OrganizationFolder.class, "test-org");
+
+            // Add source for scanning
+            SingleSCMSource source = new SingleSCMSource("test-repo-source",
+                    new MockSCM(controller, "test-repo", new MockSCMHead("master"), null));
+            folder.getNavigators().add(new SingleSCMNavigator("test-repo", Collections.singletonList(source)));
+
+            // Perform initial scan
+            folder.scheduleBuild(0);
+            r.waitUntilNoActivity();
+
+            // Change createMultipleProjects setting
+            folder.setCreateMultipleProjects(true);
+            folder.save();
+
+            // Change projectNamePattern setting
+            folder.setProjectNamePattern(".*?(-[^.]+).*");
+            folder.save();
+
+            // Verify that folder is properly configured
+            assertTrue("createMultipleProjects should be true", folder.isCreateMultipleProjects());
+            assertEquals("Project name pattern should be set", ".*?(-[^.]+).*", folder.getProjectNamePattern());
+
+            // Note: In a real test environment, we would verify that rescans are triggered
+            // but this requires more complex setup with listeners
+        }
+    }
+
+    /**
+     * Tests backward compatibility - that existing configurations still work.
+     */
+    @Test
+    public void testBackwardCompatibility() throws Exception {
+        OrganizationFolder folder = r.jenkins.createProject(OrganizationFolder.class, "legacy-folder");
+
+        // Ensure default values work for existing configurations
+        assertFalse("Legacy folders should have createMultipleProjects as false", folder.isCreateMultipleProjects());
+        assertNotNull("Legacy folders should have default project name pattern", folder.getProjectNamePattern());
+
+        // Test that existing functionality still works
+        try (MockSCMController controller = MockSCMController.create()) {
+            controller.createRepository("legacy-project");
+
+            // Add source for scanning
+            SingleSCMSource source = new SingleSCMSource("legacy-project-source",
+                    new MockSCM(controller, "legacy-project", new MockSCMHead("master"), null));
+            folder.getNavigators().add(new SingleSCMNavigator("legacy-project", Collections.singletonList(source)));
+
+            folder.scheduleBuild(0);
+            r.waitUntilNoActivity();
+
+            // Folder should work normally even without new features enabled
+            assertNotNull("Legacy folder should still function", folder.getComputation());
+        }
+    }
+
+    /**
+     * Tests edge cases for the project name pattern.
+     */
+    @Test
+    public void testProjectNamePatternEdgeCases() throws Exception {
+        OrganizationFolder folder = r.jenkins.createProject(OrganizationFolder.class, "top");
+
+        // Test empty pattern
+        folder.setProjectNamePattern("");
+        assertEquals("Empty pattern should be handled", "", folder.getProjectNamePattern());
+
+        // Test pattern with special regex characters
+        folder.setProjectNamePattern(".*?\\-(test|prod)\\-[0-9]+.*");
+        assertEquals("Pattern with special characters should be preserved",
+                ".*?\\-(test|prod)\\-[0-9]+.*", folder.getProjectNamePattern());
+
+        // Test null pattern (should use default fallback)
+        folder.setProjectNamePattern(null);
+        assertEquals("Null pattern should use fallback", ".*?(-[^.]+).*", folder.getProjectNamePattern());
+    }
+}


### PR DESCRIPTION
### Description:

This PR implements the feature requested in [JENKINS-76325](https://issues.jenkins.io/browse/JENKINS-76325), enabling Organization Folders to create multiple projects from a single repository when multiple Jenkinsfiles are detected.

### Changes:

1. UI Enhancement:​ Added configuration options to the Organization Folder:

    - Checkbox to enable/disable multi-project mode

    - Regex pattern field to extract project name suffix from Jenkinsfile paths
    <img width="634" height="138" alt="image" src="https://github.com/user-attachments/assets/8ceb5cd7-4b37-483e-95bd-ad4b605d0a4e" />

2. Core Logic:​ Modified project recognition to create separate projects for each valid Jenkinsfile found, rather than stopping at the first match.

### Testing done

1. Automation unit tests added
2. Manual testing verified correct project creation and naming
3. Backward compatibility maintained when feature is disabled

<img width="638" height="576" alt="image" src="https://github.com/user-attachments/assets/99213ae6-b6ab-4f5e-be57-9aed2d2dd7ef" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

