### PR TITLE
Don't suppress webhook-triggered builds with INDEXING strategy

### DIFF
--- a/src/main/java/jenkins/branch/NoTriggerMultiBranchQueueDecisionHandler.java
+++ b/src/main/java/jenkins/branch/NoTriggerMultiBranchQueueDecisionHandler.java
@@ -108,7 +108,16 @@ public abstract class NoTriggerMultiBranchQueueDecisionHandler extends Queue.Que
         if (!getBranchNameOf(job).matches(property.getTriggeredBranchesRegex())) {
             return true;
         }
+        if (cause instanceof BranchIndexingCause && isComputationTriggeredByEvent(job)) {
+            return false;
+        }
         return property.getStrategy().shouldSuppress(cause);
+    }
+
+    private static boolean isComputationTriggeredByEvent(Job<?, ?> job) {
+        MultiBranchProject<?, ?> project = (MultiBranchProject<?, ?>) job.getParent();
+        return project.getComputation().getCauses().stream()
+                .anyMatch(BranchEventCause.class::isInstance);
     }
 
     private static String getBranchNameOf(Job<?, ?> job) {

--- a/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerBranchPropertyTest.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import hudson.model.CauseAction;
 import jenkins.branch.harness.MultiBranchImpl;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
@@ -159,6 +160,23 @@ public class NoTriggerBranchPropertyTest {
         }
     }
 
+    @Issue("JENKINS-71144")
+    @Test
+    public void allowIndexingWhenTriggeredByEvent() throws Exception {
+        try (MockSCMController controller = MockSCMController.create()) {
+            ProjectWrapper project = createProject(controller, NoTriggerMultiBranchQueueDecisionHandler.SuppressionStrategy.INDEXING);
+            assertThat(project.getNextBuildNumber(), is(1));
+            project.triggerIndexing();
+            assertThat(project.getNextBuildNumber(), is(1));
+            project.triggerEventTriggeredIndexing();
+            assertThat(project.getNextBuildNumber(), is(2));
+            project.triggerIndexing();
+            assertThat(project.getNextBuildNumber(), is(2));
+            project.triggerEvent();
+            assertThat(project.getNextBuildNumber(), is(3));
+        }
+    }
+
     @Issue("JENKINS-63673")
     @Test
     public void suppressEvents() throws Exception {
@@ -241,6 +259,17 @@ public class NoTriggerBranchPropertyTest {
         public void triggerIndexing() throws Exception {
             bumpHeadRevision();
             project.scheduleBuild2(0).getFuture().get();
+            jenkinsRule.waitUntilNoActivity();
+            showComputation(project);
+        }
+
+        public void triggerEventTriggeredIndexing() throws Exception {
+            String revision = bumpHeadRevision();
+            MockSCMHeadEvent event = new MockSCMHeadEvent(
+                "test", SCMEvent.Type.UPDATED, controller, repositoryName, BRANCH_NAME, revision);
+            project.scheduleBuild2(0,
+                new CauseAction(new BranchEventCause(event, "test event")))
+                .getFuture().get();
             jenkinsRule.waitUntilNoActivity();
             showComputation(project);
         }

--- a/src/test/java/jenkins/branch/NoTriggerMultiBranchQueueDecisionHandlerTest.java
+++ b/src/test/java/jenkins/branch/NoTriggerMultiBranchQueueDecisionHandlerTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Action;
 import hudson.model.Cause;
@@ -214,6 +215,47 @@ public class NoTriggerMultiBranchQueueDecisionHandlerTest {
         assertThat(result, is(Boolean.TRUE));
     }
 
+    @Test
+    public void scheduleForIndexingCauseWhenComputationTriggeredByEventAndIndexingStrategyIsSet() {
+        List<Cause> computationCauses = Arrays.asList(new BranchEventCause(mock(SCMEvent.class), "event trigger"));
+        JobImpl job = mockMultiBranchJob("test", computationCauses);
+        NoTriggerProperty noTriggerProperty = new NoTriggerPropertyImpl("test", SuppressionStrategy.INDEXING);
+        NoTriggerMultiBranchQueueDecisionHandler handler = createHandler(noTriggerProperty);
+        List<Action> actions = Arrays.asList(mockCauseAction(createCause(BRANCH_INDEXING_CAUSE_ID)));
+
+        boolean result = handler.shouldSchedule(job, actions);
+
+        assertThat(result, is(Boolean.TRUE));
+    }
+
+    @Test
+    public void scheduleForIndexingCauseWhenComputationTriggeredByMultipleCausesAndIndexingStrategyIsSet() {
+        List<Cause> computationCauses = Arrays.asList(
+                new BranchIndexingCause(),
+                new BranchEventCause(mock(SCMEvent.class), "event trigger"));
+        JobImpl job = mockMultiBranchJob("test", computationCauses);
+        NoTriggerProperty noTriggerProperty = new NoTriggerPropertyImpl("test", SuppressionStrategy.INDEXING);
+        NoTriggerMultiBranchQueueDecisionHandler handler = createHandler(noTriggerProperty);
+        List<Action> actions = Arrays.asList(mockCauseAction(createCause(BRANCH_INDEXING_CAUSE_ID)));
+
+        boolean result = handler.shouldSchedule(job, actions);
+
+        assertThat(result, is(Boolean.TRUE));
+    }
+
+    @Test
+    public void suppressForEventCauseEvenWhenComputationTriggeredByEventAndEventsStrategyIsSet() {
+        List<Cause> computationCauses = Arrays.asList(new BranchEventCause(mock(SCMEvent.class), "event trigger"));
+        JobImpl job = mockMultiBranchJob("test", computationCauses);
+        NoTriggerProperty noTriggerProperty = new NoTriggerPropertyImpl("test", SuppressionStrategy.EVENTS);
+        NoTriggerMultiBranchQueueDecisionHandler handler = createHandler(noTriggerProperty);
+        List<Action> actions = Arrays.asList(mockCauseAction(createCause(BRANCH_EVENT_CAUSE_ID)));
+
+        boolean result = handler.shouldSchedule(job, actions);
+
+        assertThat(result, is(Boolean.FALSE));
+    }
+
     private static NoTriggerMultiBranchQueueDecisionHandler createHandler() {
         return new NoTriggerMultiBranchQueueDecisionHandlerImpl(Collections.emptyList());
     }
@@ -223,6 +265,10 @@ public class NoTriggerMultiBranchQueueDecisionHandlerTest {
     }
 
     private static JobImpl mockMultiBranchJob(String branchName) {
+        return mockMultiBranchJob(branchName, Collections.emptyList());
+    }
+
+    private static JobImpl mockMultiBranchJob(String branchName, List<Cause> computationCauses) {
         JobImpl job = mock(JobImpl.class);
         MultiBranchProject project = mock(MultiBranchProject.class);
         when(job.getParent()).thenReturn(project);
@@ -231,6 +277,9 @@ public class NoTriggerMultiBranchQueueDecisionHandlerTest {
         Branch branch = mock(Branch.class);
         when(factory.getBranch(job)).thenReturn(branch);
         when(branch.getName()).thenReturn(branchName);
+        FolderComputation computation = mock(FolderComputation.class);
+        when(project.getComputation()).thenReturn(computation);
+        when(computation.getCauses()).thenReturn(computationCauses);
         return job;
     }
 


### PR DESCRIPTION
Fixes #820.
Also related to #776.

When an `OrganizationFolder` webhook discovers a new repository or branch, the folder computation is correctly scheduled with a `BranchEventCause`. However, `MultiBranchProject.computeChildren()` queues the child branch build with `BranchIndexingCause`.

That makes `NoTriggerMultiBranchQueueDecisionHandler` treat the build as ordinary indexing and suppress it when `SuppressionStrategy.INDEXING` is configured, even though the original trigger was a webhook.

This change checks the current multibranch computation causes before suppressing an indexing-caused build. If the computation was triggered by `BranchEventCause`, the build is allowed to proceed.

### Testing done
- Tests covering the fix: event-triggered indexing allows build, pure indexing still suppressed, multiple causes (indexing + webhook) allows build, EVENTS strategy unaffected
- Manually tested on a live Jenkins instance: created a new empty repo under an org, pushed a Jenkinsfile to a branch. Before: build suppressed. After: build triggered correctly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
